### PR TITLE
zig plug: the eight-rung ladder, rebased onto Update 43

### DIFF
--- a/codex/plugs/zig/ZigEmitter.codex
+++ b/codex/plugs/zig/ZigEmitter.codex
@@ -177,7 +177,7 @@ Section: Type Mapping
     is FunTy (p) (fnrow) (r) -> emit-zig-fn-type ty
     is EffectfulTy (effs) (scopes) (inner) -> emit-zig-type inner
     is ForAllEff (c) (inner) -> emit-zig-type inner
-    is RecordTy (n) (a) (f) -> zig-sanitize (n.value)
+    is RecordTy (n) (a) (f) -> zig-sanitize (n.value) & zig-type-args a
     is SumTy (n) (a) (c) -> zig-sanitize (n.value) & zig-type-args a
     is ConstructedTy (n) (a) -> zig-sanitize (n.value) & zig-type-args a
     is TypeCon (n) -> zig-sanitize (n.value)
@@ -395,6 +395,13 @@ Section: Constructor Map
  body has to follow. A const alias does not avoid the rule; it reaches
  into the nested struct's function too.
 
+ bound-names lists the codex names that are runtime locals of the zig
+ function being emitted -- its parameters, its let bindings, its match
+ binders. Top-level definitions are not in it and never need capturing.
+ A lambda intersects this list with the names its body mentions, and what
+ falls out is exactly what its environment has to carry, because zig lets
+ a nested function reach a comptime constant but not a runtime value.
+
   ZigCtx = record {
    arities : List ArityEntry,
    ctors : List ZigCtorEntry,
@@ -405,7 +412,8 @@ Section: Constructor Map
    renamed-to : List Text,
    tvar-ids : List (Integer between 0 and 4294967295),
    tvar-types : List CodexType,
-   expected : CodexType
+   expected : CodexType,
+   bound-names : List Text
   }
 
  An empty list literal reaches the IR without a concrete element type,
@@ -479,7 +487,7 @@ Section: Constructor Map
    in if di < 0 then VoidTy
    else let d = list-at (ctx.irdefs) di
    in if i >= list-length (d.params) then VoidTy
-      else zig-subst-all ((list-at (d.params) i).type-val) ctx 0
+      else zig-subst-ctx ((list-at (d.params) i).type-val) ctx
 
   zig-param-ll-elem : ZigCtx, Text, Integer -> Text
   zig-param-ll-elem (ctx) (fname) (argi) =
@@ -491,7 +499,7 @@ Section: Constructor Map
    else let d = list-at defs i
    in if d.name == fname then
     (if argi >= list-length (d.params) then ""
-     else let pty = zig-subst-all ((list-at (d.params) argi).type-val) ctx 0
+     else let pty = zig-subst-ctx ((list-at (d.params) argi).type-val) ctx
      in when pty
       is ListTy (elem) -> emit-zig-type elem
       is LinkedListTy (elem) -> emit-zig-type elem
@@ -611,12 +619,20 @@ Section: Builtin Emitter
     is IrTextLit (s) (sp) -> zig-field-name s
     is otherwise -> "@compileError(\"__record-set needs a literal field name\")"
 
+  zig-record-set-plain-field : IRExpr -> Text
+  zig-record-set-plain-field (e) =
+   when e
+    is IrTextLit (s) (sp) -> zig-plain-field-name s
+    is otherwise -> ""
+
   zig-record-set : List IRExpr, ZigCtx, Integer -> Text
   zig-record-set (args) (ctx) (d) =
    let tmp = "_r" & integer-to-text d
+   in let rec-name = zig-type-name-of (zig-expr-type (list-at args 0))
+   in let field-name = zig-record-set-plain-field (list-at args 1)
    in zig-label d & ": { var " & tmp & " = " & emit-zig-expr (list-at args 0) ctx (d + 1)
     & "; " & tmp & "." & zig-record-set-field (list-at args 1)
-    & " = " & emit-zig-expr (list-at args 2) ctx (d + 1)
+    & " = " & zig-field-value-text rec-name field-name (list-at args 2) ctx d
     & "; break :" & zig-label d & " " & tmp & "; }"
 
   zig-builtin-emitters : List ZigBuiltinEmitter =
@@ -746,7 +762,8 @@ Section: Name Mapping
     renamed-to = to,
     tvar-ids = ctx.tvar-ids,
     tvar-types = ctx.tvar-types,
-    expected = ctx.expected
+    expected = ctx.expected,
+    bound-names = (ctx.bound-names) & [p.name]
    }
    in zig-push-lambda-renames ctx2 params d (i + 1)
 
@@ -1020,10 +1037,10 @@ Section: Expression Emission
     is IrName (n) (ty) (sp) -> emit-zig-name n ty ctx d
     is IrBinary (op) (l) (r) (ty) (sp) -> emit-zig-binary op l r ctx d
     is IrNegate (operand) (nty) (sp) -> "(-" & emit-zig-expr operand ctx (d + 1) & ")"
-    is IrIf (c) (t) (el) (ty) (sp) -> "(if (" & emit-zig-expr c ctx (d + 1) & ") " & emit-zig-if-branch t ty el (zig-expect ctx ty) d & " else " & emit-zig-if-branch el ty t (zig-expect ctx ty) d & ")"
+    is IrIf (c) (t) (el) (ty) (sp) -> zig-pin-lit t el ("(if (" & emit-zig-expr c ctx (d + 1) & ") " & emit-zig-if-branch t ty el (zig-expect ctx ty) d & " else " & emit-zig-if-branch el ty t (zig-expect ctx ty) d & ")")
     is IrLet (name) (ty) (val) (body) (sp) ->
      if zig-is-seq-name name then zig-label d & ": { _ = " & emit-zig-expr val ctx (d + 1) & "; break :" & zig-label d & " " & emit-zig-expr body ctx (d + 1) & "; }"
-     else if zig-occurs body name then zig-label d & ": { const " & zig-sanitize name & " = " & emit-zig-expr val ctx (d + 1) & "; break :" & zig-label d & " " & emit-zig-expr body ctx (d + 1) & "; }"
+     else if zig-occurs body name then zig-label d & ": { const " & zig-sanitize name & " = " & emit-zig-expr val ctx (d + 1) & "; break :" & zig-label d & " " & emit-zig-expr body (zig-push-bound ctx name) (d + 1) & "; }"
      else zig-label d & ": { _ = " & emit-zig-expr val ctx (d + 1) & "; break :" & zig-label d & " " & emit-zig-expr body ctx (d + 1) & "; }"
     is IrApply (f) (a) (ty) (sp) -> emit-zig-apply e ctx d
     is IrLambda (params) (body) (ty) (sp) -> zig-lambda-closure params body ty ctx d
@@ -1032,7 +1049,7 @@ Section: Expression Emission
     is IrAct (stmts) (ty) (sp) -> emit-zig-act stmts ctx d (zig-type-is-void ty)
     is IrHandle (eff) (body) (clauses) (ty) (sp) -> emit-zig-expr body ctx (d + 1)
     is IrWithTimeout (secs) (effs) (scopes) (body) (ty) (sp) -> emit-zig-expr body ctx (d + 1)
-    is IrRecord (name) (fields) (ty) (sp) -> emit-zig-record name fields ctx d
+    is IrRecord (name) (fields) (ty) (sp) -> emit-zig-record name fields ctx d (zig-ctor-type-args ty)
     is IrFieldAccess (rec) (field) (ty) (sp) -> emit-zig-expr rec ctx (d + 1) & "." & zig-field-name field
     is IrFieldStore (rec) (field) (val) (ty) (sp) ->
      if zig-is-mutable-rec ctx (zig-expr-type rec)
@@ -1079,17 +1096,147 @@ Section: Expression Emission
 
 Section: Lambda and List Helpers
 
+ An if whose branches are number literals peer-resolves to comptime_int or
+ comptime_float, and zig refuses to let a comptime-only value come out of a
+ runtime branch: `(moved.dead + (if (dead.ok) 0 else 1))` is rejected even
+ though the addition would have coerced it. Codex's Integer is i64 wherever
+ it lands and its Real is f64, so the if names that type outright and peer
+ resolution has a runtime type to agree on. Only a literal branch needs it;
+ every other expression already carries a runtime type of its own.
+
+  zig-is-int-lit : IRExpr -> Boolean
+  zig-is-int-lit (e) =
+   when e
+    is IrIntLit (n) (sp) -> True
+    is otherwise -> False
+
+  zig-is-num-lit : IRExpr -> Boolean
+  zig-is-num-lit (e) =
+   when e
+    is IrNumLit (n) (sp) -> True
+    is otherwise -> False
+
+  zig-pin-lit : IRExpr, IRExpr, Text -> Text
+  zig-pin-lit (t) (el) (s) =
+   if zig-is-int-lit t | zig-is-int-lit el then "@as(i64, " & s & ")"
+   else if zig-is-num-lit t | zig-is-num-lit el then "@as(f64, " & s & ")"
+   else s
+
  A synthesized lambda -- every `for` expression becomes one, since the
  desugarer rewrites `for` into map-list -- carries no useful type on its
  parameters, so reading p.type-val emits anyopaque, which zig refuses as a
  parameter type outright. The lambda's OWN type is the function type, so
  its spine has the answer; the parameter annotation is only the fallback.
 
- A lambda captures nothing -- anything it needed was lifted out before the
- IR reached here -- so it is a closure with an empty environment, built the
- same way a partial application is. Emitting it as a bare `.call` function
- pointer was fine while function types were pointers and disagrees with
- every one of them now that they are CxFnN.
+ A lambda captures whatever enclosing locals its body names, and the plug
+ has to build that environment by hand. Nothing lifts lambdas before the IR
+ arrives, so `map-list (\a -> resolve-type-expr tdm a) args` reaches here
+ still naming tdm, a parameter of the definition around it. Zig admits a
+ comptime constant into a nested function and refuses a runtime value, so
+ the capture is copied into the environment struct the closure already
+ carries for partial application, and the body reads it back through the
+ environment pointer.
+
+ Each capture's field type is `@TypeOf` of the value, hoisted into a
+ constant OUTSIDE the struct: the struct's own field types are read from
+ within it, where the enclosing local is exactly what zig will not let us
+ name. Naming the type would mean tracking a type for every local, and
+ @TypeOf already knows.
+
+  zig-push-bound : ZigCtx, Text -> ZigCtx
+  zig-push-bound (ctx) (n) =
+   ZigCtx {
+    arities = ctx.arities,
+    ctors = ctx.ctors,
+    mutables = ctx.mutables,
+    typedefs = ctx.typedefs,
+    irdefs = ctx.irdefs,
+    renamed-from = ctx.renamed-from,
+    renamed-to = ctx.renamed-to,
+    tvar-ids = ctx.tvar-ids,
+    tvar-types = ctx.tvar-types,
+    expected = ctx.expected,
+    bound-names = (ctx.bound-names) & [n]
+   }
+
+  zig-push-bound-params : ZigCtx, List IRParam, Integer -> ZigCtx
+  zig-push-bound-params (ctx) (params) (i) =
+   if i >= list-length params then ctx
+   else let ctx2 = zig-push-bound ctx ((list-at params i).name)
+   in zig-push-bound-params ctx2 params (i + 1)
+
+  zig-push-bound-pats : ZigCtx, List IRPat, Integer -> ZigCtx
+  zig-push-bound-pats (ctx) (subs) (i) =
+   if i >= list-length subs then ctx
+   else let b = zig-pat-binder (list-at subs i) i
+   in let ctx2 = if b == "_" then ctx else zig-push-bound ctx b
+   in zig-push-bound-pats ctx2 subs (i + 1)
+
+ A bound name is a local by construction, so it resolves without the
+ constructor and nullary-definition arms emit-zig-name has to consider.
+ Going through those would let a local named like a builtin resolve to the
+ builtin at the one place where being wrong is silent: the capture's
+ initializer would read a different value than the body does.
+
+  zig-local-ref : ZigCtx, Text -> Text
+  zig-local-ref (ctx) (n) =
+   let r = zig-renamed ctx n
+   in if text-length r > 0 then r else zig-sanitize n
+
+  zig-params-have : List IRParam, Text, Integer -> Boolean
+  zig-params-have (params) (n) (i) =
+   if i >= list-length params then False
+   else if (list-at params i).name == n then True
+   else zig-params-have params n (i + 1)
+
+  zig-captures : ZigCtx, IRExpr, List IRParam, Integer, List Text -> List Text
+  zig-captures (ctx) (body) (params) (i) (acc) =
+   if i >= list-length (ctx.bound-names) then acc
+   else let n = list-at (ctx.bound-names) i
+   in let fresh = (zig-in-texts acc n 0 == False) & (zig-params-have params n 0 == False)
+   in let acc2 = if zig-occurs body n & fresh then acc & [n] else acc
+   in zig-captures ctx body params (i + 1) acc2
+
+  zig-capture-type-decls : ZigCtx, List Text, Integer, Integer -> Text
+  zig-capture-type-decls (ctx) (caps) (i) (d) =
+   if i >= list-length caps then ""
+   else "const _Cap" & integer-to-text d & "_" & integer-to-text i & " = @TypeOf("
+    & zig-local-ref ctx (list-at caps i) & "); "
+    & zig-capture-type-decls ctx caps (i + 1) d
+
+  zig-capture-fields : List Text, Integer, Integer -> Text
+  zig-capture-fields (caps) (i) (d) =
+   if i >= list-length caps then ""
+   else "c" & integer-to-text i & ": _Cap" & integer-to-text d & "_" & integer-to-text i & ", "
+    & zig-capture-fields caps (i + 1) d
+
+  zig-capture-inits : ZigCtx, List Text, Integer -> Text
+  zig-capture-inits (ctx) (caps) (i) =
+   if i >= list-length caps then ""
+   else " .c" & integer-to-text i & " = " & zig-local-ref ctx (list-at caps i) & ","
+    & zig-capture-inits ctx caps (i + 1)
+
+  zig-push-capture-renames : ZigCtx, List Text, Integer, Text -> ZigCtx
+  zig-push-capture-renames (ctx) (caps) (i) (ev) =
+   if i >= list-length caps then ctx
+   else let ctx2 = zig-rename-to ctx (list-at caps i) (ev & ".c" & integer-to-text i)
+   in zig-push-capture-renames ctx2 caps (i + 1) ev
+
+  zig-rename-to : ZigCtx, Text, Text -> ZigCtx
+  zig-rename-to (ctx) (from) (to) =
+   ZigCtx {
+    arities = ctx.arities,
+    ctors = ctx.ctors,
+    mutables = ctx.mutables,
+    typedefs = ctx.typedefs,
+    irdefs = ctx.irdefs,
+    renamed-from = (ctx.renamed-from) & [from],
+    renamed-to = (ctx.renamed-to) & [to],
+    tvar-ids = ctx.tvar-ids,
+    tvar-types = ctx.tvar-types,
+    expected = ctx.expected,
+    bound-names = ctx.bound-names
+   }
 
   zig-lambda-param-types : List IRParam, Integer, CodexType, ZigCtx -> Text
   zig-lambda-param-types (params) (i) (ty) (ctx) =
@@ -1102,20 +1249,26 @@ Section: Lambda and List Helpers
   zig-lambda-closure (params) (body) (ty) (ctx) (d) =
    let lbl = zig-label d
    in let env = "_Env" & integer-to-text d
-   in let ret = emit-zig-type (zig-peel-return ty (list-length params))
-   in let inner = zig-push-lambda-renames ctx params d 0
+   in let ev = "_e" & integer-to-text d
    in let cx = "_ctx" & integer-to-text d
-   in lbl & ": { const " & env & " = struct { fn call(" & cx & ": *anyopaque, "
+   in let caps = zig-captures ctx body params 0 []
+   in let ret = emit-zig-type (zig-peel-return ty (list-length params))
+   in let captured = zig-push-capture-renames ctx caps 0 ev
+   in let inner = zig-push-lambda-renames captured params d 0
+   in let unpack = if list-length caps == 0 then "_ = " & cx & "; "
+      else "const " & ev & ": *@This() = @ptrCast(@alignCast(" & cx & ")); "
+   in lbl & ": { " & zig-capture-type-decls ctx caps 0 d & "const " & env
+    & " = struct { " & zig-capture-fields caps 0 d & "fn call(" & cx & ": *anyopaque, "
     & emit-zig-lambda-params params 0 ty d ctx & ") " & ret
-    & " { _ = " & cx & "; return " & emit-zig-expr body inner 0 & "; } }; break :"
+    & " { " & unpack & "return " & emit-zig-expr body inner 0 & "; } }; break :"
     & lbl & " " & zig-closure-type (list-length params) (zig-lambda-param-types params 0 ty ctx) ret
-    & "{ .ctx = cx_new(" & env & "{}), .call = &" & env & ".call }; }"
+    & "{ .ctx = cx_new(" & env & "{" & zig-capture-inits ctx caps 0 & "}), .call = &" & env & ".call }; }"
 
   zig-lambda-param-type : CodexType, Integer, IRParam, ZigCtx -> Text
   zig-lambda-param-type (ty) (i) (p) (ctx) =
-   let fromty = zig-fn-nth-param (zig-subst-all ty ctx 0) i
+   let fromty = zig-fn-nth-param (zig-subst-ctx ty ctx) i
    in if text-length fromty > 0 then fromty
-      else emit-zig-type (zig-subst-all (p.type-val) ctx 0)
+      else emit-zig-type (zig-subst-ctx (p.type-val) ctx)
 
   zig-fn-nth-param : CodexType, Integer -> Text
   zig-fn-nth-param (ty) (i) =
@@ -1169,22 +1322,31 @@ Section: Lambda and List Helpers
 
 Section: Record Emission
 
-  emit-zig-record : Text, List IRFieldVal, ZigCtx, Integer -> Text
-  emit-zig-record (name) (fields) (ctx) (d) =
+ An empty list stored into a record field reads its element type off the
+ field's declaration. Both the literal `Rec { f = [] }` and the update
+ `__record-set r "f" []` land here, and they used to disagree: only the
+ literal looked the field up, so an update fell through to the no-context
+ marker.
+
+  zig-field-value-text : Text, Text, IRExpr, ZigCtx, Integer -> Text
+  zig-field-value-text (recname) (fieldname) (v) (ctx) (d) =
+   if zig-is-empty-list v == False then emit-zig-expr v ctx (d + 1)
+   else let elem = zig-record-field-ll-elem ctx recname fieldname
+   in if text-length elem > 0 then "cx_ll_empty(" & elem & ")"
+      else emit-zig-expr v ctx (d + 1)
+
+  emit-zig-record : Text, List IRFieldVal, ZigCtx, Integer, Text -> Text
+  emit-zig-record (name) (fields) (ctx) (d) (targs) =
    if zig-in-texts (ctx.mutables) name 0
    then "cx_new(" & zig-sanitize name & "S{ " & emit-zig-record-vals name fields 0 ctx d & " })"
-   else zig-sanitize name & "{ " & emit-zig-record-vals name fields 0 ctx d & " }"
+   else zig-sanitize name & targs & "{ " & emit-zig-record-vals name fields 0 ctx d & " }"
 
   emit-zig-record-vals : Text, List IRFieldVal, Integer, ZigCtx, Integer -> Text
   emit-zig-record-vals (recname) (fields) (i) (ctx) (d) =
    if i == list-length fields then ""
    else let f = list-at fields i
    in let sep = if i > 0 then ", " else ""
-   in let val = if zig-is-empty-list (f.value)
-      then let elem = zig-record-field-ll-elem ctx recname (zig-plain-field-name (f.name))
-       in if text-length elem > 0 then "cx_ll_empty(" & elem & ")"
-          else emit-zig-expr (f.value) ctx (d + 1)
-      else emit-zig-expr (f.value) ctx (d + 1)
+   in let val = zig-field-value-text recname (zig-plain-field-name (f.name)) (f.value) ctx d
    in sep & "." & zig-field-name (f.name) & " = " & val & emit-zig-record-vals recname fields (i + 1) ctx d
 
 Section: Match Emission
@@ -1199,6 +1361,7 @@ Section: Match Emission
   zig-type-name-of (ty) =
    when ty
     is SumTy (n) (a) (c) -> n.value
+    is RecordTy (n) (a) (f) -> n.value
     is ConstructedTy (n) (a) -> n.value
     is EffectfulTy (effs) (scopes) (inner) -> zig-type-name-of inner
     is otherwise -> ""
@@ -1297,10 +1460,10 @@ Section: Match Emission
       let binder = zig-pat-binder (list-at subs 0) 0
       in if (binder == "_") | (zig-occurs body binder == False)
          then "." & zig-sanitize name & " => " & emit-zig-expr body ctx (d + 1) & ", "
-         else "." & zig-sanitize name & " => |" & zig-sanitize binder & "| " & emit-zig-expr body ctx (d + 1) & ", "
+         else "." & zig-sanitize name & " => |" & zig-sanitize binder & "| " & emit-zig-expr body (zig-push-bound ctx binder) (d + 1) & ", "
      else if zig-any-sub-occurs subs 0 body == False
      then "." & zig-sanitize name & " => " & emit-zig-expr body ctx (d + 1) & ", "
-     else "." & zig-sanitize name & " => |_p" & integer-to-text d & "| " & zig-label d & ": { " & emit-zig-pat-unpack subs 0 d body & "break :" & zig-label d & " " & emit-zig-expr body ctx (d + 1) & "; }, "
+     else "." & zig-sanitize name & " => |_p" & integer-to-text d & "| " & zig-label d & ": { " & emit-zig-pat-unpack subs 0 d body & "break :" & zig-label d & " " & emit-zig-expr body (zig-push-bound-pats ctx subs 0) (d + 1) & "; }, "
     is IrVarPat (name) (ty) (sp) -> "else => " & emit-zig-expr body ctx (d + 1) & ", "
     is IrWildPat (sp) -> "else => " & emit-zig-expr body ctx (d + 1) & ", "
     is IrVecPat (pats) (ty) (sp) -> "@compileError(\"zig plug: vector patterns not supported\"), "
@@ -1356,13 +1519,16 @@ Section: Act Emission
    if i == list-length stmts then ""
    else let s = list-at stmts i
    in let is-last = i == list-length stmts - 1
+   in let rest = when s
+    is IrDoBind (name) (ty) (val) (sp) -> if zig-is-seq-name name then ctx else zig-push-bound ctx name
+    is otherwise -> ctx
    in (when s
     is IrDoBind (name) (ty) (val) (sp) ->
      if zig-is-seq-name name then "_ = " & emit-zig-expr val ctx (d + 1) & "; "
      else "const " & zig-sanitize name & " = " & emit-zig-expr val ctx (d + 1) & "; "
     is IrDoExec (e) (sp) ->
      if is-last then (if voidp then "_ = " & emit-zig-expr e ctx (d + 1) & "; break :" & zig-label d & "; " else "break :" & zig-label d & " " & emit-zig-expr e ctx (d + 1) & "; ")
-     else "_ = " & emit-zig-expr e ctx (d + 1) & "; ") & emit-zig-act-stmts stmts (i + 1) ctx d voidp
+     else "_ = " & emit-zig-expr e ctx (d + 1) & "; ") & emit-zig-act-stmts stmts (i + 1) rest d voidp
 
 Section: Apply Emission
 
@@ -1378,7 +1544,7 @@ Section: Apply Emission
      else let ci = zig-find-ctor (ctx.ctors) n 0
      in if ci >= 0 then emit-zig-ctor-apply (list-at (ctx.ctors) ci) args ctx d (zig-ctor-type-args (zig-expr-type e))
      else let ar = lookup-arity (ctx.arities) n
-     in if ar < 0 then zig-closure-invoke (zig-sanitize n) args ctx d
+     in if ar < 0 then zig-closure-invoke (zig-local-ref ctx n) args ctx d
         else if list-length args < ar then zig-closure-make n args ctx d (zig-expr-type e)
         else zig-sanitize n & "(" & zig-call-type-args ctx n args (zig-expr-type e)
              & emit-zig-call-args n args (zig-call-ctx ctx n args (zig-expr-type e)) d 0 & ")"
@@ -1494,14 +1660,28 @@ Section: Apply Emission
     renamed-to = ctx.renamed-to,
     tvar-ids = ctx.tvar-ids,
     tvar-types = ctx.tvar-types,
-    expected = ty
+    expected = ty,
+    bound-names = ctx.bound-names
    }
+
+ Two map-list calls in one expression each bind map-list's OWN type
+ variables, so the context ends up holding two bindings for the same id.
+ Substituting from the front let the outer call's binding reach the inner
+ lambda and type its parameter as the outer element type: the inner
+ `for fld in c.fields` came out taking a SumCtor because the enclosing
+ `for c in ctors` had already bound that variable. Bindings are appended as
+ the walk descends, so the innermost is last, and the scan runs from the
+ END -- the same shadowing rule, and the same answer, as the rename table.
+
+  zig-subst-ctx : CodexType, ZigCtx -> CodexType
+  zig-subst-ctx (ty) (ctx) =
+   zig-subst-all ty ctx (list-length (ctx.tvar-ids) - 1)
 
   zig-subst-all : CodexType, ZigCtx, Integer -> CodexType
   zig-subst-all (ty) (ctx) (i) =
-   if i >= list-length (ctx.tvar-ids) then ty
+   if i < 0 then ty
    else let one = zig-subst-tvar ty (list-at (ctx.tvar-ids) i) (list-at (ctx.tvar-types) i)
-   in zig-subst-all one ctx (i + 1)
+   in zig-subst-all one ctx (i - 1)
 
   zig-bind-tvars : ZigCtx, IRDef, List (Integer between 0 and 4294967295), Integer, List IRExpr, CodexType -> ZigCtx
   zig-bind-tvars (ctx) (d) (ids) (i) (args) (resty) =
@@ -1518,7 +1698,8 @@ Section: Apply Emission
     renamed-to = ctx.renamed-to,
     tvar-ids = (ctx.tvar-ids) & [id],
     tvar-types = (ctx.tvar-types) & [bound],
-    expected = ctx.expected
+    expected = ctx.expected,
+    bound-names = ctx.bound-names
    }
    in zig-bind-tvars ctx2 d ids (i + 1) args resty
 
@@ -1634,6 +1815,7 @@ Section: Apply Emission
   zig-ctor-type-args (ty) =
    when ty
     is SumTy (n) (a) (c) -> zig-type-args a
+    is RecordTy (n) (a) (f) -> zig-type-args a
     is ConstructedTy (n) (a) -> zig-type-args a
     is otherwise -> ""
 
@@ -1798,7 +1980,8 @@ Section: Definition Emission
     renamed-to = (ctx.renamed-to) & ["_arg_" & zig-sanitize nm],
     tvar-ids = ctx.tvar-ids,
     tvar-types = ctx.tvar-types,
-    expected = ctx.expected
+    expected = ctx.expected,
+    bound-names = ctx.bound-names
    }
    in zig-push-param-renames ctx2 params (i + 1)
 
@@ -1829,11 +2012,12 @@ Section: Definition Emission
     renamed-to = ctx0.renamed-to,
     tvar-ids = ctx0.tvar-ids,
     tvar-types = ctx0.tvar-types,
-    expected = zig-def-return-type d
+    expected = zig-def-return-type d,
+    bound-names = []
    }
    in "fn " & name & "(" & all-params & ") " & ret & " {\n"
     & emit-zig-param-discards (d.params) 0 (d.body)
-    & "    return " & emit-zig-expr (d.body) (zig-push-param-renames ctx (d.params) 0) 0 & ";\n}\n\n"
+    & "    return " & emit-zig-expr (d.body) (zig-push-bound-params (zig-push-param-renames ctx (d.params) 0) (d.params) 0) 0 & ";\n}\n\n"
 
  A parameter the body never mentions is a hard error in zig, not a warning,
  so a definition that ignores an argument needs the discard written out.
@@ -1956,7 +2140,8 @@ Section: Chapter Emission
     renamed-to = [],
     tvar-ids = [],
     tvar-types = [],
-    expected = VoidTy
+    expected = VoidTy,
+    bound-names = []
    }
    in let types-text = emit-zig-type-defs type-defs 0
    in let defs-text = emit-zig-defs (m.defs) 0 ctx

--- a/codex/plugs/zig/ZigEmitter.codex
+++ b/codex/plugs/zig/ZigEmitter.codex
@@ -181,7 +181,77 @@ Section: Type Mapping
     is SumTy (n) (a) (c) -> zig-sanitize (n.value) & zig-type-args a
     is ConstructedTy (n) (a) -> zig-sanitize (n.value) & zig-type-args a
     is TypeCon (n) -> zig-sanitize (n.value)
+    is TypeVar (id) -> "T" & integer-to-text id
     is otherwise -> "@compileError(\"zig plug: no zig type for this codex type\")"
+
+ A definition quantified over type variables becomes a zig function taking
+ those types as comptime parameters, the same move generic TYPES already
+ make. Zig will not accept anyopaque as a parameter type at all, so
+ map-list : (a -> b), List a -> List b has nowhere to put a and b without
+ this.
+
+ CSharpPlug declares the equivalent and stops there, because C# infers a
+ call's type arguments. Zig does not infer a comptime type parameter, so
+ the call site has to name them, and naming them means recovering each
+ variable from the types actually passed.
+
+  zig-has-int : List (Integer between 0 and 4294967295), Integer between 0 and 4294967295, Integer -> Boolean
+  zig-has-int (xs) (n) (i) =
+   if i >= list-length xs then False
+   else if list-at xs i == n then True
+   else zig-has-int xs n (i + 1)
+
+  zig-tvar-ids : CodexType, List (Integer between 0 and 4294967295) -> List (Integer between 0 and 4294967295)
+  zig-tvar-ids (ty) (acc) =
+   when ty
+    is TypeVar (id) -> if zig-has-int acc id 0 then acc else acc & [id]
+    is FunTy (p) (fnrow) (r) -> zig-tvar-ids r (zig-tvar-ids p acc)
+    is ListTy (elem) -> zig-tvar-ids elem acc
+    is LinkedListTy (elem) -> zig-tvar-ids elem acc
+    is EffectfulTy (effs) (scopes) (inner) -> zig-tvar-ids inner acc
+    is ForAllEff (c) (inner) -> zig-tvar-ids inner acc
+    is ConstructedTy (n) (args) -> zig-tvar-ids-list args acc 0
+    is SumTy (n) (args) (c) -> zig-tvar-ids-list args acc 0
+    is RecordTy (n) (args) (f) -> zig-tvar-ids-list args acc 0
+    is otherwise -> acc
+
+  zig-tvar-ids-list : List CodexType, List (Integer between 0 and 4294967295), Integer -> List (Integer between 0 and 4294967295)
+  zig-tvar-ids-list (types) (acc) (i) =
+   if i >= list-length types then acc
+   else zig-tvar-ids-list types (zig-tvar-ids (list-at types i) acc) (i + 1)
+
+ Recovering one variable: walk the declared type and the type actually
+ supplied in step, and answer with the zig type sitting where the variable
+ sits. An empty answer means this pair does not mention it, and the caller
+ tries the next one.
+
+  zig-tvar-in : Integer between 0 and 4294967295, CodexType, CodexType -> Text
+  zig-tvar-in (id) (decl) (actual) =
+   when decl
+    is TypeVar (vid) -> if vid == id then emit-zig-type actual else ""
+    is EffectfulTy (e) (s) (inner) -> zig-tvar-in id inner actual
+    is ForAllEff (c) (inner) -> zig-tvar-in id inner actual
+    is ListTy (elem) -> zig-tvar-in-elem id elem actual
+    is LinkedListTy (elem) -> zig-tvar-in-elem id elem actual
+    is FunTy (p) (fnrow) (r) -> zig-tvar-in-fun id p r actual
+    is otherwise -> ""
+
+  zig-tvar-in-elem : Integer between 0 and 4294967295, CodexType, CodexType -> Text
+  zig-tvar-in-elem (id) (elem) (actual) =
+   when actual
+    is ListTy (ae) -> zig-tvar-in id elem ae
+    is LinkedListTy (ae) -> zig-tvar-in id elem ae
+    is EffectfulTy (e) (s) (inner) -> zig-tvar-in-elem id elem inner
+    is otherwise -> ""
+
+  zig-tvar-in-fun : Integer between 0 and 4294967295, CodexType, CodexType, CodexType -> Text
+  zig-tvar-in-fun (id) (p) (r) (actual) =
+   when actual
+    is FunTy (ap) (afnrow) (ar) ->
+     let fromp = zig-tvar-in id p ap
+     in if text-length fromp > 0 then fromp else zig-tvar-in id r ar
+    is EffectfulTy (e) (s) (inner) -> zig-tvar-in-fun id p r inner
+    is otherwise -> ""
 
  Record fields and ctor payloads are declared as ATypeExpr in the type
  defs the plug receives, so they get their own mapping onto the same
@@ -332,7 +402,9 @@ Section: Constructor Map
    typedefs : List ATypeDef,
    irdefs : List IRDef,
    renamed-from : List Text,
-   renamed-to : List Text
+   renamed-to : List Text,
+   tvar-ids : List (Integer between 0 and 4294967295),
+   tvar-types : List CodexType
   }
 
  An empty list literal reaches the IR without a concrete element type,
@@ -398,20 +470,20 @@ Section: Constructor Map
 
   zig-param-ll-elem : ZigCtx, Text, Integer -> Text
   zig-param-ll-elem (ctx) (fname) (argi) =
-   zig-param-ll-scan (ctx.irdefs) 0 fname argi
+   zig-param-ll-scan (ctx.irdefs) 0 fname argi ctx
 
-  zig-param-ll-scan : List IRDef, Integer, Text, Integer -> Text
-  zig-param-ll-scan (defs) (i) (fname) (argi) =
+  zig-param-ll-scan : List IRDef, Integer, Text, Integer, ZigCtx -> Text
+  zig-param-ll-scan (defs) (i) (fname) (argi) (ctx) =
    if i >= list-length defs then ""
    else let d = list-at defs i
    in if d.name == fname then
     (if argi >= list-length (d.params) then ""
-     else let pty = (list-at (d.params) argi).type-val
+     else let pty = zig-subst-all ((list-at (d.params) argi).type-val) ctx 0
      in when pty
       is ListTy (elem) -> emit-zig-type elem
       is LinkedListTy (elem) -> emit-zig-type elem
       is otherwise -> "")
-   else zig-param-ll-scan defs (i + 1) fname argi
+   else zig-param-ll-scan defs (i + 1) fname argi ctx
 
  Mutable records have reference semantics on bare metal: a field store
  mutates the object every holder sees. The zig emission mirrors that by
@@ -652,7 +724,9 @@ Section: Name Mapping
     typedefs = ctx.typedefs,
     irdefs = ctx.irdefs,
     renamed-from = from,
-    renamed-to = to
+    renamed-to = to,
+    tvar-ids = ctx.tvar-ids,
+    tvar-types = ctx.tvar-types
    }
    in zig-push-lambda-renames ctx2 params d (i + 1)
 
@@ -921,7 +995,7 @@ Section: Expression Emission
      else if zig-occurs body name then zig-label d & ": { const " & zig-sanitize name & " = " & emit-zig-expr val ctx (d + 1) & "; break :" & zig-label d & " " & emit-zig-expr body ctx (d + 1) & "; }"
      else zig-label d & ": { _ = " & emit-zig-expr val ctx (d + 1) & "; break :" & zig-label d & " " & emit-zig-expr body ctx (d + 1) & "; }"
     is IrApply (f) (a) (ty) (sp) -> emit-zig-apply e ctx d
-    is IrLambda (params) (body) (ty) (sp) -> "struct { fn call(" & emit-zig-lambda-params params 0 ty d & ") " & emit-zig-type (zig-peel-return ty (list-length params)) & " { return " & emit-zig-expr body (zig-push-lambda-renames ctx params d 0) 0 & "; } }.call"
+    is IrLambda (params) (body) (ty) (sp) -> zig-lambda-closure params body ty ctx d
     is IrList (elems) (ty) (sp) -> emit-zig-list elems ty ctx d
     is IrMatch (scrut) (branches) (ty) (sp) -> emit-zig-match scrut branches ctx d
     is IrAct (stmts) (ty) (sp) -> emit-zig-act stmts ctx d (zig-type-is-void ty)
@@ -980,10 +1054,36 @@ Section: Lambda and List Helpers
  parameter type outright. The lambda's OWN type is the function type, so
  its spine has the answer; the parameter annotation is only the fallback.
 
-  zig-lambda-param-type : CodexType, Integer, IRParam -> Text
-  zig-lambda-param-type (ty) (i) (p) =
-   let fromty = zig-fn-nth-param ty i
-   in if text-length fromty > 0 then fromty else emit-zig-type (p.type-val)
+ A lambda captures nothing -- anything it needed was lifted out before the
+ IR reached here -- so it is a closure with an empty environment, built the
+ same way a partial application is. Emitting it as a bare `.call` function
+ pointer was fine while function types were pointers and disagrees with
+ every one of them now that they are CxFnN.
+
+  zig-lambda-param-types : List IRParam, Integer, CodexType, ZigCtx -> Text
+  zig-lambda-param-types (params) (i) (ty) (ctx) =
+   if i >= list-length params then ""
+   else let one = zig-lambda-param-type ty i (list-at params i) ctx
+   in if i == list-length params - 1 then one
+      else one & ", " & zig-lambda-param-types params (i + 1) ty ctx
+
+  zig-lambda-closure : List IRParam, IRExpr, CodexType, ZigCtx, Integer -> Text
+  zig-lambda-closure (params) (body) (ty) (ctx) (d) =
+   let lbl = zig-label d
+   in let env = "_Env" & integer-to-text d
+   in let ret = emit-zig-type (zig-peel-return ty (list-length params))
+   in let inner = zig-push-lambda-renames ctx params d 0
+   in lbl & ": { const " & env & " = struct { fn call(ctx: *anyopaque, "
+    & emit-zig-lambda-params params 0 ty d ctx & ") " & ret
+    & " { _ = ctx; return " & emit-zig-expr body inner 0 & "; } }; break :"
+    & lbl & " " & zig-closure-type (list-length params) (zig-lambda-param-types params 0 ty ctx) ret
+    & "{ .ctx = cx_new(" & env & "{}), .call = &" & env & ".call }; }"
+
+  zig-lambda-param-type : CodexType, Integer, IRParam, ZigCtx -> Text
+  zig-lambda-param-type (ty) (i) (p) (ctx) =
+   let fromty = zig-fn-nth-param (zig-subst-all ty ctx 0) i
+   in if text-length fromty > 0 then fromty
+      else emit-zig-type (zig-subst-all (p.type-val) ctx 0)
 
   zig-fn-nth-param : CodexType, Integer -> Text
   zig-fn-nth-param (ty) (i) =
@@ -991,13 +1091,13 @@ Section: Lambda and List Helpers
     is FunTy (p) (fnrow) (r) -> if i == 0 then emit-zig-type p else zig-fn-nth-param r (i - 1)
     is otherwise -> ""
 
-  emit-zig-lambda-params : List IRParam, Integer, CodexType, Integer -> Text
-  emit-zig-lambda-params (params) (i) (ty) (d) =
+  emit-zig-lambda-params : List IRParam, Integer, CodexType, Integer, ZigCtx -> Text
+  emit-zig-lambda-params (params) (i) (ty) (d) (ctx) =
    if i == list-length params then ""
    else let p = list-at params i
-   in let one = zig-lambda-param-name (p.name) d & ": " & zig-lambda-param-type ty i p
+   in let one = zig-lambda-param-name (p.name) d & ": " & zig-lambda-param-type ty i p ctx
    in if i == list-length params - 1 then one
-   else one & ", " & emit-zig-lambda-params params (i + 1) ty d
+   else one & ", " & emit-zig-lambda-params params (i + 1) ty d ctx
 
  A literal with elements carries its own answer: the first element's type
  is what the list holds, and it needs no context at all. The annotation
@@ -1208,7 +1308,8 @@ Section: Apply Emission
      else let ar = lookup-arity (ctx.arities) n
      in if ar < 0 then zig-closure-invoke (zig-sanitize n) args ctx d
         else if list-length args < ar then zig-closure-make n args ctx d (zig-expr-type e)
-        else zig-sanitize n & "(" & emit-zig-call-args n args ctx d 0 & ")"
+        else zig-sanitize n & "(" & zig-call-type-args ctx n args (zig-expr-type e)
+             & emit-zig-call-args n args (zig-call-ctx ctx n args (zig-expr-type e)) d 0 & ")"
     is otherwise -> emit-zig-expr-curried e ctx d
 
  Codex applies partially: a 4-argument function called with 2 yields
@@ -1222,6 +1323,154 @@ Section: Apply Emission
  partial application itself, which is exactly the function type left over.
  A name with no arity is not a definition, so it is a value already
  holding a closure, and applying it goes through the trampoline.
+
+ Each variable is recovered from the first argument whose declared type
+ mentions it, falling back to the result. map-list needs both routes: `a`
+ comes from `List a` against the list passed, and `b` only from the result
+ `List b`, because the lambda's own type is as unresolved as the parameter
+ was. A variable no argument mentions emits anyopaque, which zig refuses
+ loudly rather than inferring something wrong.
+
+ A resolved type variable has to reach the arguments, not just the type
+ argument list. A lambda handed to map-list carries the CALLEE's variable
+ in its own type, and an empty list typed from the callee's declared
+ parameter carries it too -- emitted as-is, both name a variable that does
+ not exist in the caller. The call site already knows T36 is Token; these
+ rewrite the argument's type before it is emitted so the emitter never
+ sees a foreign variable.
+
+ Substituting the TYPE rather than threading a binding table through
+ emit-zig-type is what keeps this to one place. emit-zig-type is called
+ from three dozen functions and knows only the type it is given; it should
+ stay that way.
+
+  zig-subst-tvar : CodexType, Integer, CodexType -> CodexType
+  zig-subst-tvar (ty) (id) (with-ty) =
+   when ty
+    is TypeVar (vid) -> if vid == id then with-ty else ty
+    is ListTy (elem) -> ListTy (zig-subst-tvar elem id with-ty)
+    is LinkedListTy (elem) -> LinkedListTy (zig-subst-tvar elem id with-ty)
+    is FunTy (p) (fnrow) (r) -> FunTy (zig-subst-tvar p id with-ty) fnrow (zig-subst-tvar r id with-ty)
+    is EffectfulTy (e) (s) (inner) -> EffectfulTy e s (zig-subst-tvar inner id with-ty)
+    is ForAllEff (c) (inner) -> ForAllEff c (zig-subst-tvar inner id with-ty)
+    is otherwise -> ty
+
+  zig-subst-arg-type : CodexType, IRDef, List IRExpr, CodexType, List Integer, Integer -> CodexType
+  zig-subst-arg-type (ty) (d) (args) (resty) (ids) (i) =
+   if i >= list-length ids then ty
+   else let id = list-at ids i
+   in let bound = zig-resolve-tvar-type id d args resty 0
+   in zig-subst-arg-type (zig-subst-tvar ty id bound) d args resty ids (i + 1)
+
+ zig-resolve-tvar answers with emitted text because the type argument list
+ needs text. Substitution needs the TYPE, so the walk is shared and only
+ the answer differs.
+
+  zig-resolve-tvar-type : Integer, IRDef, List IRExpr, CodexType, Integer -> CodexType
+  zig-resolve-tvar-type (id) (d) (args) (resty) (i) =
+   if i >= list-length (d.params) | i >= list-length args
+   then zig-tvar-in-type id (zig-peel-return (d.type-val) (list-length (d.params))) resty
+   else let found = zig-tvar-in-type id ((list-at (d.params) i).type-val) (zig-expr-type (list-at args i))
+   in when found
+      is VoidTy -> zig-resolve-tvar-type id d args resty (i + 1)
+      is otherwise -> found
+
+  zig-tvar-in-type : Integer, CodexType, CodexType -> CodexType
+  zig-tvar-in-type (id) (decl) (actual) =
+   when decl
+    is TypeVar (vid) -> if vid == id then actual else VoidTy
+    is EffectfulTy (e) (s) (inner) -> zig-tvar-in-type id inner actual
+    is ForAllEff (c) (inner) -> zig-tvar-in-type id inner actual
+    is ListTy (elem) -> zig-tvar-in-elem-type id elem actual
+    is LinkedListTy (elem) -> zig-tvar-in-elem-type id elem actual
+    is FunTy (p) (fnrow) (r) -> zig-tvar-in-fun-type id p r actual
+    is otherwise -> VoidTy
+
+  zig-tvar-in-elem-type : Integer, CodexType, CodexType -> CodexType
+  zig-tvar-in-elem-type (id) (elem) (actual) =
+   when actual
+    is ListTy (ae) -> zig-tvar-in-type id elem ae
+    is LinkedListTy (ae) -> zig-tvar-in-type id elem ae
+    is EffectfulTy (e) (s) (inner) -> zig-tvar-in-elem-type id elem inner
+    is otherwise -> VoidTy
+
+  zig-tvar-in-fun-type : Integer, CodexType, CodexType, CodexType -> CodexType
+  zig-tvar-in-fun-type (id) (p) (r) (actual) =
+   when actual
+    is FunTy (ap) (afnrow) (ar) ->
+     let fromp = zig-tvar-in-type id p ap
+     in when fromp
+        is VoidTy -> zig-tvar-in-type id r ar
+        is otherwise -> fromp
+    is EffectfulTy (e) (s) (inner) -> zig-tvar-in-fun-type id p r inner
+    is otherwise -> VoidTy
+
+  zig-subst-all : CodexType, ZigCtx, Integer -> CodexType
+  zig-subst-all (ty) (ctx) (i) =
+   if i >= list-length (ctx.tvar-ids) then ty
+   else let one = zig-subst-tvar ty (list-at (ctx.tvar-ids) i) (list-at (ctx.tvar-types) i)
+   in zig-subst-all one ctx (i + 1)
+
+  zig-bind-tvars : ZigCtx, IRDef, List (Integer between 0 and 4294967295), Integer, List IRExpr, CodexType -> ZigCtx
+  zig-bind-tvars (ctx) (d) (ids) (i) (args) (resty) =
+   if i >= list-length ids then ctx
+   else let id = list-at ids i
+   in let bound = zig-resolve-tvar-type id d args resty 0
+   in let ctx2 = ZigCtx {
+    arities = ctx.arities,
+    ctors = ctx.ctors,
+    mutables = ctx.mutables,
+    typedefs = ctx.typedefs,
+    irdefs = ctx.irdefs,
+    renamed-from = ctx.renamed-from,
+    renamed-to = ctx.renamed-to,
+    tvar-ids = (ctx.tvar-ids) & [id],
+    tvar-types = (ctx.tvar-types) & [bound]
+   }
+   in zig-bind-tvars ctx2 d ids (i + 1) args resty
+
+  zig-call-ctx : ZigCtx, Text, List IRExpr, CodexType -> ZigCtx
+  zig-call-ctx (ctx) (n) (args) (resty) =
+   let di = zig-find-irdef (ctx.irdefs) 0 n
+   in if di < 0 then ctx
+   else let d = list-at (ctx.irdefs) di
+   in let ids = zig-def-tvar-ids d
+   in if list-length ids == 0 then ctx
+   else zig-bind-tvars ctx d ids 0 args resty
+
+  zig-find-irdef : List IRDef, Integer, Text -> Integer
+  zig-find-irdef (defs) (i) (n) =
+   if i >= list-length defs then -1
+   else if (list-at defs i).name == n then i
+   else zig-find-irdef defs (i + 1) n
+
+  zig-call-type-args : ZigCtx, Text, List IRExpr, CodexType -> Text
+  zig-call-type-args (ctx) (n) (args) (resty) =
+   let di = zig-find-irdef (ctx.irdefs) 0 n
+   in if di < 0 then ""
+   else let d = list-at (ctx.irdefs) di
+   in let ids = zig-def-tvar-ids d
+   in if list-length ids == 0 then ""
+   else zig-call-type-args-loop ctx d ids 0 args resty
+
+  zig-call-type-args-loop : ZigCtx, IRDef, List (Integer between 0 and 4294967295), Integer, List IRExpr, CodexType -> Text
+  zig-call-type-args-loop (ctx) (d) (ids) (i) (args) (resty) =
+   if i >= list-length ids then ""
+   else let one = zig-resolve-tvar (list-at ids i) d args resty 0
+   in one & ", " & zig-call-type-args-loop ctx d ids (i + 1) args resty
+
+  zig-resolve-tvar : Integer between 0 and 4294967295, IRDef, List IRExpr, CodexType, Integer -> Text
+  zig-resolve-tvar (id) (d) (args) (resty) (i) =
+   if i >= list-length (d.params) | i >= list-length args
+   then let fromres = zig-tvar-in id (zig-peel-return (d.type-val) (list-length (d.params))) resty
+    in if text-length fromres > 0 then fromres else "anyopaque"
+   else let found = zig-tvar-in id ((list-at (d.params) i).type-val) (zig-expr-type (list-at args i))
+   in if text-length found > 0 then found
+      else zig-resolve-tvar id d args resty (i + 1)
+
+  zig-drop-trailing-comma : Text -> Text
+  zig-drop-trailing-comma (s) =
+   if text-length s < 2 then s else substring s 0 (text-length s - 2)
 
   zig-closure-args : List IRExpr, ZigCtx, Integer, Integer -> Text
   zig-closure-args (args) (ctx) (d) (i) =
@@ -1379,13 +1628,56 @@ Section: Definition Emission
   zig-skip-def : Text -> Boolean
   zig-skip-def (n) = n == "subj-deck-record"
 
+ A definition's own type-val is not reliably populated -- map-list-loop's
+ is unresolved, which is why it took no comptime parameters at all even
+ though its parameters plainly use T38 and T39, and why its return type
+ came out anyopaque. The parameters carry good types when the summary type
+ does not, so both are collected.
+
+ Peeling the return off type-val only works when type-val is populated.
+ When it is not -- map-list-loop again -- the body's own type is what the
+ definition actually returns, and it is the only source left.
+
+  zig-def-return-text : IRDef -> Text
+  zig-def-return-text (d) =
+   let peeled = emit-zig-type (zig-peel-return (d.type-val) (list-length (d.params)))
+   in if zig-is-unmapped peeled then emit-zig-type (zig-expr-type (d.body)) else peeled
+
+ The marker is the signal. Which codex type an unpopulated type-val holds
+ is not something to guess at -- VoidTy was the guess and it was wrong --
+ but "emit-zig-type could not map it" is exactly what the marker records.
+
+  zig-is-unmapped : Text -> Boolean
+  zig-is-unmapped (t) =
+   if text-length t < 13 then False else substring t 0 13 == "@compileError"
+
+  zig-def-tvar-ids : IRDef -> List (Integer between 0 and 4294967295)
+  zig-def-tvar-ids (d) =
+   zig-def-param-tvars (d.params) 0 (zig-tvar-ids (d.type-val) [])
+
+  zig-def-param-tvars : List IRParam, Integer, List (Integer between 0 and 4294967295) -> List (Integer between 0 and 4294967295)
+  zig-def-param-tvars (params) (i) (acc) =
+   if i >= list-length params then acc
+   else zig-def-param-tvars params (i + 1) (zig-tvar-ids ((list-at params i).type-val) acc)
+
+  zig-comptime-params : List (Integer between 0 and 4294967295), Integer -> Text
+  zig-comptime-params (ids) (i) =
+   if i >= list-length ids then ""
+   else "comptime T" & integer-to-text (list-at ids i) & ": type, "
+      & zig-comptime-params ids (i + 1)
+
   emit-zig-def : IRDef, ZigCtx -> Text
   emit-zig-def (d) (ctx) =
    if zig-skip-def (d.name) then ""
    else let name = zig-sanitize (d.name)
    in let params-text = emit-zig-def-params (d.params) 0
-   in let ret = emit-zig-type (zig-peel-return (d.type-val) (list-length (d.params)))
-   in "fn " & name & "(" & params-text & ") " & ret & " {\n"
+   in let tvars = zig-def-tvar-ids d
+   in let comptimes = zig-comptime-params tvars 0
+   in let all-params = if text-length params-text == 0
+      then zig-drop-trailing-comma comptimes
+      else comptimes & params-text
+   in let ret = zig-def-return-text d
+   in "fn " & name & "(" & all-params & ") " & ret & " {\n"
     & emit-zig-param-discards (d.params) 0 (d.body)
     & "    return " & emit-zig-expr (d.body) ctx 0 & ";\n}\n\n"
 
@@ -1505,7 +1797,9 @@ Section: Chapter Emission
     typedefs = type-defs,
     irdefs = m.defs,
     renamed-from = [],
-    renamed-to = []
+    renamed-to = [],
+    tvar-ids = [],
+    tvar-types = []
    }
    in let types-text = emit-zig-type-defs type-defs 0
    in let defs-text = emit-zig-defs (m.defs) 0 ctx

--- a/codex/plugs/zig/ZigEmitter.codex
+++ b/codex/plugs/zig/ZigEmitter.codex
@@ -181,7 +181,7 @@ Section: Type Mapping
     is SumTy (n) (a) (c) -> zig-sanitize (n.value) & zig-type-args a
     is ConstructedTy (n) (a) -> zig-sanitize (n.value) & zig-type-args a
     is TypeCon (n) -> zig-sanitize (n.value)
-    is otherwise -> "anyopaque"
+    is otherwise -> "@compileError(\"zig plug: no zig type for this codex type\")"
 
  Record fields and ctor payloads are declared as ATypeExpr in the type
  defs the plug receives, so they get their own mapping onto the same
@@ -223,12 +223,12 @@ Section: Type Mapping
        if (bn.value == "List") | (bn.value == "LinkedList")
        then "*CxList(" & emit-zig-atype (list-at args 0) & ")"
        else zig-sanitize (bn.value) & zig-atype-args args
-      is otherwise -> "anyopaque"
+      is otherwise -> "@compileError(\"zig plug: no zig type for this applied type\")"
     is ABoundedIntType (b) (lo) (hi) (mode) (s) -> "i64"
     is AEffectType (effs) (scopes) (tail) (ret) (s) -> emit-zig-atype ret
     is AFunType (p) (r) (s) -> zig-closure-type (zig-afn-param-count te) (zig-afn-param-types te) (emit-zig-atype (zig-afn-result te))
     is ALinearType (inner) (s) -> emit-zig-atype inner
-    is otherwise -> "anyopaque"
+    is otherwise -> "@compileError(\"zig plug: no zig type for this type expression\")"
 
   zig-peel-return : CodexType, Integer -> CodexType
   zig-peel-return (ty) (n) =
@@ -498,7 +498,7 @@ Section: Builtin Emitter
   zig-ll-elem : CodexType -> Text
   zig-ll-elem (ty) =
    let e = zig-ll-elem-opt ty
-   in if text-length e > 0 then e else "i64"
+   in if text-length e > 0 then e else "@compileError(\"zig plug: no element type for this list\")"
 
  The annotation is not always a list type -- a type variable reaches here
  unresolved -- so this answers "" for that rather than a default, and the
@@ -1023,7 +1023,7 @@ Section: Lambda and List Helpers
    let annotated = zig-ll-elem-opt ty
    in let et = if text-length annotated > 0 then annotated
       else if list-length elems > 0 then emit-zig-type (zig-expr-type (list-at elems 0))
-      else "i64"
+      else "@compileError(\"zig plug: no element type for this empty list\")"
    in if list-length elems == 0 then "cx_ll_empty(" & et & ")"
       else "cx_ll_of(" & et & ", &[_]" & et & "{ " & emit-zig-list-elems elems 0 ctx d & " })"
 

--- a/codex/plugs/zig/ZigEmitter.codex
+++ b/codex/plugs/zig/ZigEmitter.codex
@@ -662,6 +662,8 @@ Section: Builtin Emitter
     ZigBuiltinEmitter { name = "print-line-raw", emit = \args ctx d ty -> "cx_print_line(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "print-line-uni", emit = \args ctx d ty -> "cx_print_line(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "print-uni", emit = \args ctx d ty -> "cx_print(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
+    ZigBuiltinEmitter { name = "print-text", emit = \args ctx d ty -> "cx_print(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
+    ZigBuiltinEmitter { name = "text-to-double-bits", emit = \args ctx d ty -> "cx_text_to_double_bits(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "print-error", emit = \args ctx d ty -> "cx_print_line(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "print-error-uni", emit = \args ctx d ty -> "cx_print_line(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "show", emit = \args ctx d ty -> "cx_show_int(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
@@ -680,7 +682,7 @@ Section: Builtin Emitter
     ZigBuiltinEmitter { name = "bit-shr", emit = \args ctx d ty -> "cx_shr(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ", " & emit-zig-expr (list-at args 1) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "list-length", emit = \args ctx d ty -> "cx_list_len(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "list-at", emit = \args ctx d ty -> "cx_list_at(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ", " & emit-zig-expr (list-at args 1) ctx (d + 1) & ")" },
-    ZigBuiltinEmitter { name = "list-push", emit = \args ctx d ty -> "cx_ll_push(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ", " & emit-zig-expr (list-at args 1) ctx (d + 1) & ")" },
+    ZigBuiltinEmitter { name = "list-push", emit = \args ctx d ty -> "cx_ll_push(" & zig-list-arg-text args 0 1 ctx d & ", " & emit-zig-expr (list-at args 1) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "list-insert-at", emit = \args ctx d ty -> "cx_ll_insert_at(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ", " & emit-zig-expr (list-at args 1) ctx (d + 1) & ", " & emit-zig-expr (list-at args 2) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "__deck-enter", emit = \args ctx d ty -> "{}" },
     ZigBuiltinEmitter { name = "__deck-exit", emit = \args ctx d ty -> "{}" },
@@ -711,16 +713,66 @@ Section: Builtin Emitter
 
 Section: Name Mapping
 
+ A name the plug cannot place used to reach zig as itself, and zig said
+ "use of undeclared identifier text_to_double_bits" -- true, unhelpful, and
+ indistinguishable from a typo in the emitter. Three builtins the plug had
+ never implemented arrived that way at once in the lower milestone, each
+ reported as a mystery identifier rather than as the missing emitter it was.
+
+ Everything a name can legitimately be is enumerable: a rename in scope, a
+ local bound by an enclosing binder, an entry in the name map, a
+ constructor, a definition in the chapter, or a builtin. Nothing else
+ exists, so anything else is a gap in this plug and names itself.
+
+ bound-names is what makes this decidable. Before captures it did not
+ exist, and a bare name that was not a definition was assumed to be a
+ closure-valued local, which is exactly the assumption that let an
+ unimplemented builtin through as a call to a nonexistent closure.
+
+  zig-is-builtin : Text -> Boolean
+  zig-is-builtin (n) =
+   let len = list-length zig-builtin-emitters
+   in let pos = bsearch-zig-builtin-pos zig-builtin-emitters n 0 len
+   in if pos >= len then False
+      else (list-at zig-builtin-emitters pos).name == n
+
+  zig-name-known : ZigCtx, Text -> Boolean
+  zig-name-known (ctx) (n) =
+   if text-length (zig-renamed ctx n) > 0 then True
+   else if zig-in-texts (ctx.bound-names) n 0 then True
+   else if text-length (zig-lookup-name zig-name-map n 0) > 0 then True
+   else if zig-find-ctor (ctx.ctors) n 0 >= 0 then True
+   else if lookup-arity (ctx.arities) n >= 0 then True
+   else zig-is-builtin n
+
+  zig-unknown-name : Text -> Text
+  zig-unknown-name (n) =
+   "@compileError(\"zig plug: no emitter for " & n & "\")"
+
+
   ZigNameEntry = record {
    codex-name : Text,
    zig-name : Text
   }
+
+ The deck names answer 0 because this target has no deck: allocation is
+ page_allocator and the stack is whatever zig-main asks for, so the
+ frontier is nowhere and nothing is ever short of it. __heap-save reads as
+ the same answer for the same reason -- Lowering guards its per-def loop
+ with (ceiling > 0) and (__heap-save + guard-band >= ceiling), which with
+ a 0 frontier is "keep going", which is true here.
+
+ This is a semantic choice rather than a translation, so it is worth being
+ clear that it stays honest: bare metal decides saturation from real
+ memory, and a subject that saturates there and not here diverges in the
+ dump the oracle diffs. The choice is checked, not assumed.
 
   zig-name-map : List ZigNameEntry =
    [ZigNameEntry { codex-name = "True", zig-name = "true" },
     ZigNameEntry { codex-name = "False", zig-name = "false" },
     ZigNameEntry { codex-name = "Nothing", zig-name = "null" },
     ZigNameEntry { codex-name = "__deck-pos", zig-name = "0" },
+    ZigNameEntry { codex-name = "__heap-save", zig-name = "0" },
     ZigNameEntry { codex-name = "__deck-enter", zig-name = "0" },
     ZigNameEntry { codex-name = "__deck-exit", zig-name = "0" }]
 
@@ -798,7 +850,8 @@ Section: Name Mapping
    else if lookup-arity (ctx.arities) n == 0 then zig-sanitize n & "()"
    else if lookup-arity (ctx.arities) n >= 1 & zig-fn-param-count ty >= 1
    then zig-closure-make n [] ctx d ty
-   else zig-sanitize n
+   else if zig-name-known ctx n then zig-sanitize n
+   else zig-unknown-name n
 
 Section: Binary Operator Mapping
 
@@ -1571,7 +1624,7 @@ Section: Apply Emission
      else let ci = zig-find-ctor (ctx.ctors) n 0
      in if ci >= 0 then emit-zig-ctor-apply (list-at (ctx.ctors) ci) args ctx d (zig-ctor-type-args (zig-expr-type e))
      else let ar = lookup-arity (ctx.arities) n
-     in if ar < 0 then zig-closure-invoke (zig-local-ref ctx n) args ctx d
+     in if ar < 0 then (if zig-name-known ctx n then zig-closure-invoke (zig-local-ref ctx n) args ctx d else zig-unknown-name n)
         else if list-length args < ar then zig-closure-make n args ctx d (zig-expr-type e)
         else zig-sanitize n & "(" & zig-call-type-args ctx n args (zig-expr-type e)
              & emit-zig-call-args n args (zig-call-ctx ctx n args (zig-expr-type e)) d 0 & ")"
@@ -1760,11 +1813,20 @@ Section: Apply Emission
    else let one = zig-resolve-tvar (list-at ids i) d args resty 0
    in one & ", " & zig-call-type-args-loop ctx d ids (i + 1) args resty
 
+ A variable no argument mentions used to come out anyopaque, on the
+ reasoning that zig refuses anyopaque and so the gap could not pass
+ silently. It cannot, but it also cannot explain itself: zig reports
+ "opaque return type not allowed" against a CxFn1 instantiation and says
+ nothing about which callee, which variable, or that a type argument is
+ what went missing. Ten of these in one subject read as one mystery rather
+ than ten facts. The marker names the callee and the variable instead.
+
   zig-resolve-tvar : Integer between 0 and 4294967295, IRDef, List IRExpr, CodexType, Integer -> Text
   zig-resolve-tvar (id) (d) (args) (resty) (i) =
    if i >= list-length (d.params) | i >= list-length args
    then let fromres = zig-tvar-in id (zig-peel-return (d.type-val) (list-length (d.params))) resty
-    in if text-length fromres > 0 then fromres else "anyopaque"
+    in if text-length fromres > 0 then fromres
+       else "@compileError(\"zig plug: unresolved type variable T" & integer-to-text id & " of " & d.name & "\")"
    else let found = zig-tvar-in id ((list-at (d.params) i).type-val) (zig-expr-type (list-at args i))
    in if text-length found > 0 then found
       else zig-resolve-tvar id d args resty (i + 1)
@@ -1881,6 +1943,29 @@ Section: Apply Emission
  A constructor payload's declared field type is an ATypeExpr rather than a
  CodexType, so the expectation is carried as text -- the one place the
  mechanism cannot use zig-expect and says why.
+
+ A builtin argument is the fourth place an empty list can learn what it
+ holds, and the first where the answer is not a declaration. `list-push []
+ x` says nothing about the list and everything about x, so the element type
+ comes off the SIBLING argument: whatever is being pushed is what the list
+ holds. Three of these sit in lower-lazy, which builds a one-element
+ parameter list and two field lists this way.
+
+ Builtin emitters take their arguments as plain expressions with no
+ expectation attached, which is why zig-expect cannot reach here. This
+ helper is the narrow substitute -- it answers for one argument of one
+ builtin from another argument of the same call, and it stays honest by
+ refusing to guess: a sibling whose own type is unresolved falls through to
+ the ordinary emission and the empty-list marker fires as before.
+
+  zig-list-arg-text : List IRExpr, Integer, Integer, ZigCtx, Integer -> Text
+  zig-list-arg-text (args) (li) (ei) (ctx) (d) =
+   let a = list-at args li
+   in if zig-is-empty-list a == False then emit-zig-expr a ctx (d + 1)
+   else let elem = emit-zig-type (zig-expr-type (list-at args ei))
+   in if text-length elem > 0 & zig-is-unmapped elem == False
+      then "cx_ll_empty(" & elem & ")"
+      else emit-zig-expr a ctx (d + 1)
 
   emit-zig-ctor-arg : ZigCtorEntry, IRExpr, ZigCtx, Integer, Integer -> Text
   emit-zig-ctor-arg (c) (a) (ctx) (d) (i) =
@@ -2127,6 +2212,7 @@ Section: Chapter Emission
    & "fn cx_ll_insert_at(l: anytype, i: i64, v: anytype) @TypeOf(l) {\n    l.items.insert(std.heap.page_allocator, @intCast(i), v) catch @panic(\"oom\");\n    return l;\n}\n"
    & "fn cx_ll_with_capacity(comptime T: type, n: i64) *CxList(T) {\n    _ = n;\n    return cx_ll_empty(T);\n}\n"
    & "fn cx_text_compare(a: []const u8, b: []const u8) i64 {\n    return switch (std.mem.order(u8, a, b)) { .lt => -1, .eq => 0, .gt => 1 };\n}\n"
+   & "fn cx_text_to_double_bits(s: []const u8) i64 {\n    _ = s;\n    @panic(\"zig plug: text-to-double-bits unimplemented\");\n}\n"
    & "fn cx_char_to_text(c: i64) []const u8 {\n    const b = std.heap.page_allocator.alloc(u8, 1) catch @panic(\"oom\");\n    b[0] = @intCast(c);\n    return b;\n}\n"
    & "fn cx_list_len(l: anytype) i64 {\n    return @intCast(l.items.items.len);\n}\n"
    & "fn cx_list_at(l: anytype, i: i64) @TypeOf(l.items.items[0]) {\n    return l.items.items[@intCast(i)];\n}\n"

--- a/codex/plugs/zig/ZigEmitter.codex
+++ b/codex/plugs/zig/ZigEmitter.codex
@@ -635,6 +635,20 @@ Section: Builtin Emitter
     & " = " & zig-field-value-text rec-name field-name (list-at args 2) ctx d
     & "; break :" & zig-label d & " " & tmp & "; }"
 
+ Text is CCE in the interior -- on bare metal, in the C# plug and here --
+ because CCE is codex semantics and not a runtime encoding choice: `E` IS
+ 39, and CCE orders letters by frequency, so a plug holding UTF-8 would
+ disagree with bare metal on every comparison, ordering and substring
+ index. A target's own encoding appears at I/O and nowhere else, which for
+ this plug means cx_cce_to_utf8 on the way to the terminal.
+
+ A Char, though, is a CODEPOINT here, which is why char-code and
+ code-to-char convert rather than vanish the way they do in the C# plug.
+ That makes char-at the odd one out: it read the CCE byte and handed it
+ back untranslated, so `char-code (char-at s i)` fed a CCE code to a table
+ that wanted a codepoint and panicked. char-code-at is the one that answers
+ in CCE, and it stays a bare read.
+
   zig-builtin-emitters : List ZigBuiltinEmitter =
    sort-zig-builtins [
     ZigBuiltinEmitter { name = "__record-set", emit = \args ctx d ty -> zig-record-set args ctx d },
@@ -678,7 +692,7 @@ Section: Builtin Emitter
     ZigBuiltinEmitter { name = "__linked-list-to-list", emit = \args ctx d ty -> emit-zig-expr (list-at args 0) ctx (d + 1) },
     ZigBuiltinEmitter { name = "__deck-pos", emit = \args ctx d ty -> "0" },
     ZigBuiltinEmitter { name = "subj-deck-record", emit = \args ctx d ty -> emit-zig-expr (list-at args 0) ctx (d + 1) },
-    ZigBuiltinEmitter { name = "char-at", emit = \args ctx d ty -> "cx_char_at(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ", " & emit-zig-expr (list-at args 1) ctx (d + 1) & ")" },
+    ZigBuiltinEmitter { name = "char-at", emit = \args ctx d ty -> "cx_cce_to_cp(cx_char_at(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ", " & emit-zig-expr (list-at args 1) ctx (d + 1) & "))" },
     ZigBuiltinEmitter { name = "negate", emit = \args ctx d ty -> "(-" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "__narrow", emit = \args ctx d ty -> emit-zig-expr (list-at args 0) ctx (d + 1) },
     ZigBuiltinEmitter { name = "abs", emit = \args ctx d ty -> "@as(i64, @intCast(@abs(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")))" },

--- a/codex/plugs/zig/ZigEmitter.codex
+++ b/codex/plugs/zig/ZigEmitter.codex
@@ -135,10 +135,25 @@ Section: Type Mapping
   emit-zig-fn-type (ty) =
    zig-closure-type (zig-fn-param-count ty) (zig-fn-param-types ty) (emit-zig-type (zig-fn-result ty))
 
+ ForAllTy is the TYPE-level quantifier and this emitter handled only the
+ effect-level one. Every place ForAllEff is unwrapped below, ForAllTy has
+ to be unwrapped too, and it was unwrapped nowhere: a quantified type had
+ no arrows to count, could not be peeled, and had no zig rendering at all.
+ lower-def in the compiler does `strip-forall-ty full-type` for exactly
+ this reason -- the quantifier says which variables are bound, and the
+ shape underneath is the type.
+
+ It stayed invisible for eight rungs because the default IR pipeline
+ inlines, and an inlined definition arrives with its quantifier already
+ gone. Turning the inline passes off -- which Passes.codex says a plug
+ emitting SOURCE must do -- is what let a polymorphic definition reach the
+ plug still quantified, and sort-by was the first to arrive that way.
+
   zig-fn-spine : CodexType -> CodexType
   zig-fn-spine (ty) =
    when ty
     is EffectfulTy (effs) (scopes) (inner) -> zig-fn-spine inner
+    is ForAllTy (fid) (inner) -> zig-fn-spine inner
     is ForAllEff (c) (inner) -> zig-fn-spine inner
     is otherwise -> ty
 
@@ -176,6 +191,7 @@ Section: Type Mapping
     is VectorMaskTy (vn) -> "@Vector(" & show vn & ", bool)"
     is FunTy (p) (fnrow) (r) -> emit-zig-fn-type ty
     is EffectfulTy (effs) (scopes) (inner) -> emit-zig-type inner
+    is ForAllTy (fid) (inner) -> emit-zig-type inner
     is ForAllEff (c) (inner) -> emit-zig-type inner
     is RecordTy (n) (a) (f) -> zig-sanitize (n.value) & zig-type-args a
     is SumTy (n) (a) (c) -> zig-sanitize (n.value) & zig-type-args a
@@ -209,6 +225,7 @@ Section: Type Mapping
     is ListTy (elem) -> zig-tvar-ids elem acc
     is LinkedListTy (elem) -> zig-tvar-ids elem acc
     is EffectfulTy (effs) (scopes) (inner) -> zig-tvar-ids inner acc
+    is ForAllTy (fid) (inner) -> zig-tvar-ids inner acc
     is ForAllEff (c) (inner) -> zig-tvar-ids inner acc
     is ConstructedTy (n) (args) -> zig-tvar-ids-list args acc 0
     is SumTy (n) (args) (c) -> zig-tvar-ids-list args acc 0
@@ -230,6 +247,7 @@ Section: Type Mapping
    when decl
     is TypeVar (vid) -> if vid == id then emit-zig-type actual else ""
     is EffectfulTy (e) (s) (inner) -> zig-tvar-in id inner actual
+    is ForAllTy (fid) (inner) -> zig-tvar-in id inner actual
     is ForAllEff (c) (inner) -> zig-tvar-in id inner actual
     is ListTy (elem) -> zig-tvar-in-elem id elem actual
     is LinkedListTy (elem) -> zig-tvar-in-elem id elem actual
@@ -304,6 +322,7 @@ Section: Type Mapping
   zig-peel-return (ty) (n) =
    when ty
     is EffectfulTy (effs) (scopes) (inner) -> zig-peel-return inner n
+    is ForAllTy (fid) (inner) -> zig-peel-return inner n
     is ForAllEff (c) (inner) -> zig-peel-return inner n
     is FunTy (p) (fnrow) (r) -> if n <= 0 then ty else zig-peel-return r (n - 1)
     is otherwise -> ty
@@ -315,6 +334,7 @@ Section: Type Mapping
     is NothingTy -> True
     is ProofTy -> True
     is EffectfulTy (effs) (scopes) (inner) -> zig-type-is-void inner
+    is ForAllTy (fid) (inner) -> zig-type-is-void inner
     is ForAllEff (c) (inner) -> zig-type-is-void inner
     is otherwise -> False
 
@@ -1696,6 +1716,7 @@ Section: Apply Emission
     is LinkedListTy (elem) -> LinkedListTy (zig-subst-tvar elem id with-ty)
     is FunTy (p) (fnrow) (r) -> FunTy (zig-subst-tvar p id with-ty) fnrow (zig-subst-tvar r id with-ty)
     is EffectfulTy (e) (s) (inner) -> EffectfulTy e s (zig-subst-tvar inner id with-ty)
+    is ForAllTy (fid) (inner) -> ForAllTy fid (zig-subst-tvar inner id with-ty)
     is ForAllEff (c) (inner) -> ForAllEff c (zig-subst-tvar inner id with-ty)
     is otherwise -> ty
 
@@ -1724,6 +1745,7 @@ Section: Apply Emission
    when decl
     is TypeVar (vid) -> if vid == id then actual else VoidTy
     is EffectfulTy (e) (s) (inner) -> zig-tvar-in-type id inner actual
+    is ForAllTy (fid) (inner) -> zig-tvar-in-type id inner actual
     is ForAllEff (c) (inner) -> zig-tvar-in-type id inner actual
     is ListTy (elem) -> zig-tvar-in-elem-type id elem actual
     is LinkedListTy (elem) -> zig-tvar-in-elem-type id elem actual

--- a/codex/plugs/zig/ZigEmitter.codex
+++ b/codex/plugs/zig/ZigEmitter.codex
@@ -556,6 +556,8 @@ Section: Builtin Emitter
     ZigBuiltinEmitter { name = "list-length", emit = \args ctx d ty -> "cx_list_len(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "list-at", emit = \args ctx d ty -> "cx_list_at(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ", " & emit-zig-expr (list-at args 1) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "list-push", emit = \args ctx d ty -> "cx_ll_push(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ", " & emit-zig-expr (list-at args 1) ctx (d + 1) & ")" },
+    ZigBuiltinEmitter { name = "list-insert-at", emit = \args ctx d ty -> "cx_ll_insert_at(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ", " & emit-zig-expr (list-at args 1) ctx (d + 1) & ", " & emit-zig-expr (list-at args 2) ctx (d + 1) & ")" },
+    ZigBuiltinEmitter { name = "char-to-text", emit = \args ctx d ty -> "cx_char_to_text(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "__linked-list-empty", emit = \args ctx d ty -> "cx_ll_empty(" & zig-ll-elem ty & ")" },
     ZigBuiltinEmitter { name = "__linked-list-push", emit = \args ctx d ty -> "cx_ll_push(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ", " & emit-zig-expr (list-at args 1) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "__linked-list-to-list", emit = \args ctx d ty -> emit-zig-expr (list-at args 0) ctx (d + 1) },
@@ -869,7 +871,7 @@ Section: Expression Emission
      else if zig-occurs body name then zig-label d & ": { const " & zig-sanitize name & " = " & emit-zig-expr val ctx (d + 1) & "; break :" & zig-label d & " " & emit-zig-expr body ctx (d + 1) & "; }"
      else zig-label d & ": { _ = " & emit-zig-expr val ctx (d + 1) & "; break :" & zig-label d & " " & emit-zig-expr body ctx (d + 1) & "; }"
     is IrApply (f) (a) (ty) (sp) -> emit-zig-apply e ctx d
-    is IrLambda (params) (body) (ty) (sp) -> "struct { fn call(" & emit-zig-lambda-params params 0 & ") " & emit-zig-type (zig-peel-return ty (list-length params)) & " { return " & emit-zig-expr body ctx 0 & "; } }.call"
+    is IrLambda (params) (body) (ty) (sp) -> "struct { fn call(" & emit-zig-lambda-params params 0 ty & ") " & emit-zig-type (zig-peel-return ty (list-length params)) & " { return " & emit-zig-expr body ctx 0 & "; } }.call"
     is IrList (elems) (ty) (sp) -> emit-zig-list elems ty ctx d
     is IrMatch (scrut) (branches) (ty) (sp) -> emit-zig-match scrut branches ctx d
     is IrAct (stmts) (ty) (sp) -> emit-zig-act stmts ctx d (zig-type-is-void ty)
@@ -922,13 +924,30 @@ Section: Expression Emission
 
 Section: Lambda and List Helpers
 
-  emit-zig-lambda-params : List IRParam, Integer -> Text
-  emit-zig-lambda-params (params) (i) =
+ A synthesized lambda -- every `for` expression becomes one, since the
+ desugarer rewrites `for` into map-list -- carries no useful type on its
+ parameters, so reading p.type-val emits anyopaque, which zig refuses as a
+ parameter type outright. The lambda's OWN type is the function type, so
+ its spine has the answer; the parameter annotation is only the fallback.
+
+  zig-lambda-param-type : CodexType, Integer, IRParam -> Text
+  zig-lambda-param-type (ty) (i) (p) =
+   let fromty = zig-fn-nth-param ty i
+   in if text-length fromty > 0 then fromty else emit-zig-type (p.type-val)
+
+  zig-fn-nth-param : CodexType, Integer -> Text
+  zig-fn-nth-param (ty) (i) =
+   when zig-fn-spine ty
+    is FunTy (p) (fnrow) (r) -> if i == 0 then emit-zig-type p else zig-fn-nth-param r (i - 1)
+    is otherwise -> ""
+
+  emit-zig-lambda-params : List IRParam, Integer, CodexType -> Text
+  emit-zig-lambda-params (params) (i) (ty) =
    if i == list-length params then ""
    else let p = list-at params i
-   in let one = zig-sanitize (p.name) & ": " & emit-zig-type (p.type-val)
+   in let one = zig-sanitize (p.name) & ": " & zig-lambda-param-type ty i p
    in if i == list-length params - 1 then one
-   else one & ", " & emit-zig-lambda-params params (i + 1)
+   else one & ", " & emit-zig-lambda-params params (i + 1) ty
 
  A literal with elements carries its own answer: the first element's type
  is what the list holds, and it needs no context at all. The annotation
@@ -1398,6 +1417,8 @@ Section: Chapter Emission
    & "fn cx_ll_of(comptime T: type, vs: []const T) *CxList(T) {\n    const l = cx_ll_empty(T);\n    l.items.appendSlice(std.heap.page_allocator, vs) catch @panic(\"oom\");\n    return l;\n}\n"
    & "fn cx_ll_concat(a: anytype, b: @TypeOf(a)) @TypeOf(a) {\n    const c = cx_new(@TypeOf(a.*){ .items = .empty });\n    c.items.appendSlice(std.heap.page_allocator, a.items.items) catch @panic(\"oom\");\n    c.items.appendSlice(std.heap.page_allocator, b.items.items) catch @panic(\"oom\");\n    return c;\n}\n"
    & "fn cx_ll_cons(v: anytype, l: anytype) @TypeOf(l) {\n    const c = cx_new(@TypeOf(l.*){ .items = .empty });\n    c.items.append(std.heap.page_allocator, v) catch @panic(\"oom\");\n    c.items.appendSlice(std.heap.page_allocator, l.items.items) catch @panic(\"oom\");\n    return c;\n}\n"
+   & "fn cx_ll_insert_at(l: anytype, i: i64, v: anytype) @TypeOf(l) {\n    const c = cx_new(@TypeOf(l.*){ .items = .empty });\n    c.items.appendSlice(std.heap.page_allocator, l.items.items) catch @panic(\"oom\");\n    c.items.insert(std.heap.page_allocator, @intCast(i), v) catch @panic(\"oom\");\n    return c;\n}\n"
+   & "fn cx_char_to_text(c: i64) []const u8 {\n    const b = std.heap.page_allocator.alloc(u8, 1) catch @panic(\"oom\");\n    b[0] = @intCast(c);\n    return b;\n}\n"
    & "fn cx_list_len(l: anytype) i64 {\n    return @intCast(l.items.items.len);\n}\n"
    & "fn cx_list_at(l: anytype, i: i64) @TypeOf(l.items.items[0]) {\n    return l.items.items[@intCast(i)];\n}\n"
    & "fn cx_text_len(s: []const u8) i64 {\n    return @intCast(s.len);\n}\n"

--- a/codex/plugs/zig/ZigEmitter.codex
+++ b/codex/plugs/zig/ZigEmitter.codex
@@ -317,12 +317,22 @@ Section: Constructor Map
    enum-like : Boolean
   }
 
+ renamed-from and renamed-to are parallel: a name emitted inside a lambda
+ body is looked up in the first and emitted as the matching entry of the
+ second. Zig forbids a nested function's parameter from shadowing an
+ enclosing one, and the desugarer produces exactly that -- `for p in pats`
+ inside desugar-pattern(p) -- so the lambda's parameter is renamed and its
+ body has to follow. A const alias does not avoid the rule; it reaches
+ into the nested struct's function too.
+
   ZigCtx = record {
    arities : List ArityEntry,
    ctors : List ZigCtorEntry,
    mutables : List Text,
    typedefs : List ATypeDef,
-   irdefs : List IRDef
+   irdefs : List IRDef,
+   renamed-from : List Text,
+   renamed-to : List Text
   }
 
  An empty list literal reaches the IR without a concrete element type,
@@ -608,9 +618,49 @@ Section: Name Mapping
  closure with nothing captured -- the same shape a partial application
  produces, which is what keeps every function-typed position one type.
 
+ The scan runs from the END so an inner lambda's binding wins over an
+ outer one of the same name, which is what shadowing means. Appending with
+ `&` rather than list-push is not a style choice: list-push writes in place
+ under capacity and returns the same list, so pushing onto a list the
+ caller still holds mutates it for every later caller. Done with list-push,
+ these renames escaped their lambda and reached every definition emitted
+ afterwards -- apat_span(p) emitted _lam3_p for its own parameter.
+
+  zig-renamed : ZigCtx, Text -> Text
+  zig-renamed (ctx) (n) =
+   zig-renamed-scan ctx n (list-length (ctx.renamed-from) - 1)
+
+  zig-renamed-scan : ZigCtx, Text, Integer -> Text
+  zig-renamed-scan (ctx) (n) (i) =
+   if i < 0 then ""
+   else if list-at (ctx.renamed-from) i == n then list-at (ctx.renamed-to) i
+   else zig-renamed-scan ctx n (i - 1)
+
+  zig-lambda-param-name : Text, Integer -> Text
+  zig-lambda-param-name (n) (d) = "_lam" & integer-to-text d & "_" & zig-sanitize n
+
+  zig-push-lambda-renames : ZigCtx, List IRParam, Integer, Integer -> ZigCtx
+  zig-push-lambda-renames (ctx) (params) (d) (i) =
+   if i >= list-length params then ctx
+   else let p = list-at params i
+   in let from = (ctx.renamed-from) & [p.name]
+   in let to = (ctx.renamed-to) & [zig-lambda-param-name (p.name) d]
+   in let ctx2 = ZigCtx {
+    arities = ctx.arities,
+    ctors = ctx.ctors,
+    mutables = ctx.mutables,
+    typedefs = ctx.typedefs,
+    irdefs = ctx.irdefs,
+    renamed-from = from,
+    renamed-to = to
+   }
+   in zig-push-lambda-renames ctx2 params d (i + 1)
+
   emit-zig-name : Text, CodexType, ZigCtx, Integer -> Text
   emit-zig-name (n) (ty) (ctx) (d) =
-   let mapped = zig-lookup-name zig-name-map n 0
+   let renamed = zig-renamed ctx n
+   in if text-length renamed > 0 then renamed
+   else let mapped = zig-lookup-name zig-name-map n 0
    in if text-length mapped > 0 then mapped
    else let ci = zig-find-ctor (ctx.ctors) n 0
    in if ci >= 0 then
@@ -871,7 +921,7 @@ Section: Expression Emission
      else if zig-occurs body name then zig-label d & ": { const " & zig-sanitize name & " = " & emit-zig-expr val ctx (d + 1) & "; break :" & zig-label d & " " & emit-zig-expr body ctx (d + 1) & "; }"
      else zig-label d & ": { _ = " & emit-zig-expr val ctx (d + 1) & "; break :" & zig-label d & " " & emit-zig-expr body ctx (d + 1) & "; }"
     is IrApply (f) (a) (ty) (sp) -> emit-zig-apply e ctx d
-    is IrLambda (params) (body) (ty) (sp) -> "struct { fn call(" & emit-zig-lambda-params params 0 ty & ") " & emit-zig-type (zig-peel-return ty (list-length params)) & " { return " & emit-zig-expr body ctx 0 & "; } }.call"
+    is IrLambda (params) (body) (ty) (sp) -> "struct { fn call(" & emit-zig-lambda-params params 0 ty d & ") " & emit-zig-type (zig-peel-return ty (list-length params)) & " { return " & emit-zig-expr body (zig-push-lambda-renames ctx params d 0) 0 & "; } }.call"
     is IrList (elems) (ty) (sp) -> emit-zig-list elems ty ctx d
     is IrMatch (scrut) (branches) (ty) (sp) -> emit-zig-match scrut branches ctx d
     is IrAct (stmts) (ty) (sp) -> emit-zig-act stmts ctx d (zig-type-is-void ty)
@@ -941,13 +991,13 @@ Section: Lambda and List Helpers
     is FunTy (p) (fnrow) (r) -> if i == 0 then emit-zig-type p else zig-fn-nth-param r (i - 1)
     is otherwise -> ""
 
-  emit-zig-lambda-params : List IRParam, Integer, CodexType -> Text
-  emit-zig-lambda-params (params) (i) (ty) =
+  emit-zig-lambda-params : List IRParam, Integer, CodexType, Integer -> Text
+  emit-zig-lambda-params (params) (i) (ty) (d) =
    if i == list-length params then ""
    else let p = list-at params i
-   in let one = zig-sanitize (p.name) & ": " & zig-lambda-param-type ty i p
+   in let one = zig-lambda-param-name (p.name) d & ": " & zig-lambda-param-type ty i p
    in if i == list-length params - 1 then one
-   else one & ", " & emit-zig-lambda-params params (i + 1) ty
+   else one & ", " & emit-zig-lambda-params params (i + 1) ty d
 
  A literal with elements carries its own answer: the first element's type
  is what the list holds, and it needs no context at all. The annotation
@@ -1453,7 +1503,9 @@ Section: Chapter Emission
     ctors = build-ctor-map type-defs 0 [],
     mutables = build-mutable-set type-defs 0 [],
     typedefs = type-defs,
-    irdefs = m.defs
+    irdefs = m.defs,
+    renamed-from = [],
+    renamed-to = []
    }
    in let types-text = emit-zig-type-defs type-defs 0
    in let defs-text = emit-zig-defs (m.defs) 0 ctx

--- a/codex/plugs/zig/ZigEmitter.codex
+++ b/codex/plugs/zig/ZigEmitter.codex
@@ -1529,15 +1529,8 @@ Section: Match Emission
   emit-zig-match-arms (branches) (i) (ctx) (d) (ex) (mty) =
    if i == list-length branches then ""
    else let b = list-at branches i
-   in let dup = zig-pat-is-catch-all (b.pattern) & zig-catch-all-before branches 0 i
-   in (if dup then "" else emit-zig-match-arm (b.pattern) (b.body) (zig-expect ctx mty) d ex mty)
+   in emit-zig-match-arm (b.pattern) (b.body) (zig-expect ctx mty) d ex mty
       & emit-zig-match-arms branches (i + 1) ctx d ex mty
-
-  zig-catch-all-before : List IRBranch, Integer, Integer -> Boolean
-  zig-catch-all-before (branches) (i) (stop) =
-   if i >= stop then False
-   else if zig-pat-is-catch-all ((list-at branches i).pattern) then True
-   else zig-catch-all-before branches (i + 1) stop
 
  Constructor arms bind payloads: one field binds by name directly; a
  tuple payload binds `_p<d>` and unpacks into consts inside a labeled

--- a/codex/plugs/zig/ZigEmitter.codex
+++ b/codex/plugs/zig/ZigEmitter.codex
@@ -652,6 +652,9 @@ Section: Builtin Emitter
     ZigBuiltinEmitter { name = "list-at", emit = \args ctx d ty -> "cx_list_at(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ", " & emit-zig-expr (list-at args 1) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "list-push", emit = \args ctx d ty -> "cx_ll_push(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ", " & emit-zig-expr (list-at args 1) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "list-insert-at", emit = \args ctx d ty -> "cx_ll_insert_at(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ", " & emit-zig-expr (list-at args 1) ctx (d + 1) & ", " & emit-zig-expr (list-at args 2) ctx (d + 1) & ")" },
+    ZigBuiltinEmitter { name = "__deck-enter", emit = \args ctx d ty -> "{}" },
+    ZigBuiltinEmitter { name = "__deck-exit", emit = \args ctx d ty -> "{}" },
+    ZigBuiltinEmitter { name = "__list-with-capacity", emit = \args ctx d ty -> "cx_ll_with_capacity(" & zig-ll-elem ty & ", " & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "text-compare", emit = \args ctx d ty -> "cx_text_compare(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ", " & emit-zig-expr (list-at args 1) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "char-to-text", emit = \args ctx d ty -> "cx_char_to_text(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "__linked-list-empty", emit = \args ctx d ty -> "cx_ll_empty(" & zig-ll-elem ty & ")" },
@@ -687,7 +690,9 @@ Section: Name Mapping
    [ZigNameEntry { codex-name = "True", zig-name = "true" },
     ZigNameEntry { codex-name = "False", zig-name = "false" },
     ZigNameEntry { codex-name = "Nothing", zig-name = "null" },
-    ZigNameEntry { codex-name = "__deck-pos", zig-name = "0" }]
+    ZigNameEntry { codex-name = "__deck-pos", zig-name = "0" },
+    ZigNameEntry { codex-name = "__deck-enter", zig-name = "0" },
+    ZigNameEntry { codex-name = "__deck-exit", zig-name = "0" }]
 
   zig-lookup-name : List ZigNameEntry, Text, Integer -> Text
   zig-lookup-name (entries) (name) (i) =
@@ -755,7 +760,10 @@ Section: Name Mapping
    in if ci >= 0 then
     let c = list-at (ctx.ctors) ci
     in if c.enum-like then zig-sanitize (c.type-name) & "." & zig-sanitize n
-       else zig-sanitize (c.type-name) & zig-ctor-type-args ty & "{ ." & zig-sanitize n & " = {} }"
+       else let boxed = zig-typedef-recursive ctx (c.type-name)
+       in let base = if boxed then zig-sanitize (c.type-name) & "S" else zig-sanitize (c.type-name) & zig-ctor-type-args ty
+       in if boxed then "cx_new(" & base & "{ ." & zig-sanitize n & " = {} })"
+          else base & "{ ." & zig-sanitize n & " = {} }"
    else if lookup-arity (ctx.arities) n == 0 then zig-sanitize n & "()"
    else if lookup-arity (ctx.arities) n >= 1 & zig-fn-param-count ty >= 1
    then zig-closure-make n [] ctx d ty
@@ -1096,9 +1104,10 @@ Section: Lambda and List Helpers
    in let env = "_Env" & integer-to-text d
    in let ret = emit-zig-type (zig-peel-return ty (list-length params))
    in let inner = zig-push-lambda-renames ctx params d 0
-   in lbl & ": { const " & env & " = struct { fn call(ctx: *anyopaque, "
+   in let cx = "_ctx" & integer-to-text d
+   in lbl & ": { const " & env & " = struct { fn call(" & cx & ": *anyopaque, "
     & emit-zig-lambda-params params 0 ty d ctx & ") " & ret
-    & " { _ = ctx; return " & emit-zig-expr body inner 0 & "; } }; break :"
+    & " { _ = " & cx & "; return " & emit-zig-expr body inner 0 & "; } }; break :"
     & lbl & " " & zig-closure-type (list-length params) (zig-lambda-param-types params 0 ty ctx) ret
     & "{ .ctx = cx_new(" & env & "{}), .call = &" & env & ".call }; }"
 
@@ -1231,7 +1240,15 @@ Section: Match Emission
   emit-zig-match-arms (branches) (i) (ctx) (d) (ex) (mty) =
    if i == list-length branches then ""
    else let b = list-at branches i
-   in emit-zig-match-arm (b.pattern) (b.body) (zig-expect ctx mty) d ex mty & emit-zig-match-arms branches (i + 1) ctx d ex mty
+   in let dup = zig-pat-is-catch-all (b.pattern) & zig-catch-all-before branches 0 i
+   in (if dup then "" else emit-zig-match-arm (b.pattern) (b.body) (zig-expect ctx mty) d ex mty)
+      & emit-zig-match-arms branches (i + 1) ctx d ex mty
+
+  zig-catch-all-before : List IRBranch, Integer, Integer -> Boolean
+  zig-catch-all-before (branches) (i) (stop) =
+   if i >= stop then False
+   else if zig-pat-is-catch-all ((list-at branches i).pattern) then True
+   else zig-catch-all-before branches (i + 1) stop
 
  Constructor arms bind payloads: one field binds by name directly; a
  tuple payload binds `_p<d>` and unpacks into consts inside a labeled
@@ -1286,7 +1303,7 @@ Section: Match Emission
      else "." & zig-sanitize name & " => |_p" & integer-to-text d & "| " & zig-label d & ": { " & emit-zig-pat-unpack subs 0 d body & "break :" & zig-label d & " " & emit-zig-expr body ctx (d + 1) & "; }, "
     is IrVarPat (name) (ty) (sp) -> "else => " & emit-zig-expr body ctx (d + 1) & ", "
     is IrWildPat (sp) -> "else => " & emit-zig-expr body ctx (d + 1) & ", "
-    is IrVecPat (pats) (ty) (sp) -> "else => " & emit-zig-expr body ctx (d + 1) & ", "
+    is IrVecPat (pats) (ty) (sp) -> "@compileError(\"zig plug: vector patterns not supported\"), "
 
   zig-any-sub-occurs : List IRPat, Integer, IRExpr -> Boolean
   zig-any-sub-occurs (subs) (i) (body) =
@@ -1597,10 +1614,11 @@ Section: Apply Emission
    in let env = "_Env" & integer-to-text d
    in let ev = "_e" & integer-to-text d
    in let ret = emit-zig-type (zig-fn-result pty)
-   in let unpack = if list-length args == 0 then "_ = ctx; "
-      else "const " & ev & ": *@This() = @ptrCast(@alignCast(ctx)); "
+   in let cx = "_ctx" & integer-to-text d
+   in let unpack = if list-length args == 0 then "_ = " & cx & "; "
+      else "const " & ev & ": *@This() = @ptrCast(@alignCast(" & cx & ")); "
    in lbl & ": { const " & env & " = struct { " & zig-closure-fields args ctx 0
-    & "fn call(ctx: *anyopaque, " & zig-closure-params pty 0 & ") " & ret
+    & "fn call(" & cx & ": *anyopaque, " & zig-closure-params pty 0 & ") " & ret
     & " { " & unpack & "return " & zig-sanitize n & "("
     & zig-closure-env-refs ev (list-length args) 0 & zig-closure-pass rem 0 & "); } }; break :"
     & lbl & " " & zig-closure-type rem (zig-fn-param-types pty) ret
@@ -1896,6 +1914,7 @@ Section: Chapter Emission
    & "fn cx_ll_concat(a: anytype, b: @TypeOf(a)) @TypeOf(a) {\n    const c = cx_new(@TypeOf(a.*){ .items = .empty });\n    c.items.appendSlice(std.heap.page_allocator, a.items.items) catch @panic(\"oom\");\n    c.items.appendSlice(std.heap.page_allocator, b.items.items) catch @panic(\"oom\");\n    return c;\n}\n"
    & "fn cx_ll_cons(v: anytype, l: anytype) @TypeOf(l) {\n    const c = cx_new(@TypeOf(l.*){ .items = .empty });\n    c.items.append(std.heap.page_allocator, v) catch @panic(\"oom\");\n    c.items.appendSlice(std.heap.page_allocator, l.items.items) catch @panic(\"oom\");\n    return c;\n}\n"
    & "fn cx_ll_insert_at(l: anytype, i: i64, v: anytype) @TypeOf(l) {\n    l.items.insert(std.heap.page_allocator, @intCast(i), v) catch @panic(\"oom\");\n    return l;\n}\n"
+   & "fn cx_ll_with_capacity(comptime T: type, n: i64) *CxList(T) {\n    _ = n;\n    return cx_ll_empty(T);\n}\n"
    & "fn cx_text_compare(a: []const u8, b: []const u8) i64 {\n    return switch (std.mem.order(u8, a, b)) { .lt => -1, .eq => 0, .gt => 1 };\n}\n"
    & "fn cx_char_to_text(c: i64) []const u8 {\n    const b = std.heap.page_allocator.alloc(u8, 1) catch @panic(\"oom\");\n    b[0] = @intCast(c);\n    return b;\n}\n"
    & "fn cx_list_len(l: anytype) i64 {\n    return @intCast(l.items.items.len);\n}\n"

--- a/codex/plugs/zig/ZigEmitter.codex
+++ b/codex/plugs/zig/ZigEmitter.codex
@@ -318,6 +318,31 @@ Section: Type Mapping
     is ForAllEff (c) (inner) -> zig-type-is-void inner
     is otherwise -> False
 
+ Every node that CARRIES a type answers with it, and the one that does not
+ is the reason this list is long. IrLet holds the type of the name it
+ BINDS, not of the expression: `let len = list-length xs in ...` would
+ answer Integer, which is len's type and not the let's. A let is worth
+ whatever its body is worth, so it recurses.
+
+ Falling into otherwise means answering VoidTy, and void is a legitimate
+ codex type rather than a marker, so a missing arm here is indistinguishable
+ from a genuinely void expression. sort-by paid for that: its body is a let,
+ the let answered void, and with an empty type-val on the definition the
+ emitter had nothing better to fall back to, so it declared a function
+ returning void around a body returning a list.
+
+ IrLambda is missing ON PURPOSE and answering it costs five milestones. A
+ lambda handed to map-list carries the CALLEE's type variables, so a caller
+ asking "what type is this argument" gets `a -> b` in map-list's own
+ numbering. Resolving map-list's `a` against that answers `a` with itself,
+ and T26 reaches zig in a function that declares no such thing. Silence
+ here is what makes the resolver skip the lambda and recover the element
+ type from the list argument instead, which is the answer that works.
+
+ The other type-carrying nodes are absent for a duller reason: nothing has
+ needed them. A missing one shows up as a wrong void, loudly, the way this
+ one did.
+
   zig-expr-type : IRExpr -> CodexType
   zig-expr-type (e) =
    when e
@@ -329,6 +354,7 @@ Section: Type Mapping
     is IrIf (c) (t) (el) (ty) (sp) -> ty
     is IrMatch (scrut) (branches) (ty) (sp) -> ty
     is IrRecord (name) (fields) (ty) (sp) -> ty
+    is IrLet (n) (ty) (v) (b) (sp) -> zig-expr-type b
     is otherwise -> VoidTy
 
   zig-is-text-type : CodexType -> Boolean
@@ -2030,14 +2056,48 @@ Section: Definition Emission
  When it is not -- map-list-loop again -- the body's own type is what the
  definition actually returns, and it is the only source left.
 
+ A type-val carrying FEWER arrows than the definition has parameters is
+ not describing this definition, and peeling it cannot be trusted:
+ zig-peel-return stops when it runs out of arrows and hands back whatever
+ is left, so an unpopulated type-val peels to itself and an unpopulated
+ VoidTy peels to a perfectly valid "void". The marker check below cannot
+ see that, because void is a mapping rather than a gap -- sort-by emitted
+ as returning void while its body returned a list, and zig caught it only
+ because the body disagreed.
+
+ The arrow count is the test. It is not a guess about what the type should
+ have been: it is the observation that this type cannot be the type of a
+ definition taking this many parameters, whereupon the body's own type is
+ the answer, exactly as it is for an unmapped one.
+
+ Taking the return type off the body is the right answer but a silent one,
+ and how often it happens is worth knowing rather than guessing: sort-by
+ was caught only because its body returned a list into a void signature,
+ and a definition whose body really is void would have taken the wrong
+ answer without a word. The note is a zig comment, so counting them costs
+ nothing and cannot break a build.
+
+  zig-untrusted-return-note : IRDef -> Text
+  zig-untrusted-return-note (d) =
+   if zig-def-return-trusted d then ""
+   else "    // zig plug: return type from body; type-val has "
+    & integer-to-text (zig-fn-param-count (d.type-val)) & " arrows for "
+    & integer-to-text (list-length (d.params)) & " params\n"
+
+  zig-def-return-trusted : IRDef -> Boolean
+  zig-def-return-trusted (d) =
+   zig-fn-param-count (d.type-val) >= list-length (d.params)
+
   zig-def-return-type : IRDef -> CodexType
   zig-def-return-type (d) =
-   let peeled = zig-peel-return (d.type-val) (list-length (d.params))
+   if zig-def-return-trusted d == False then zig-expr-type (d.body)
+   else let peeled = zig-peel-return (d.type-val) (list-length (d.params))
    in if zig-is-unmapped (emit-zig-type peeled) then zig-expr-type (d.body) else peeled
 
   zig-def-return-text : IRDef -> Text
   zig-def-return-text (d) =
-   let peeled = emit-zig-type (zig-peel-return (d.type-val) (list-length (d.params)))
+   if zig-def-return-trusted d == False then emit-zig-type (zig-expr-type (d.body))
+   else let peeled = emit-zig-type (zig-peel-return (d.type-val) (list-length (d.params)))
    in if zig-is-unmapped peeled then emit-zig-type (zig-expr-type (d.body)) else peeled
 
  The marker is the signal. Which codex type an unpopulated type-val holds
@@ -2128,6 +2188,7 @@ Section: Definition Emission
     bound-names = []
    }
    in "fn " & name & "(" & all-params & ") " & ret & " {\n"
+    & zig-untrusted-return-note d
     & emit-zig-param-discards (d.params) 0 (d.body)
     & "    return " & emit-zig-expr (d.body) (zig-push-bound-params (zig-push-param-renames ctx (d.params) 0) (d.params) 0) 0 & ";\n}\n\n"
 

--- a/codex/plugs/zig/ZigEmitter.codex
+++ b/codex/plugs/zig/ZigEmitter.codex
@@ -404,7 +404,8 @@ Section: Constructor Map
    renamed-from : List Text,
    renamed-to : List Text,
    tvar-ids : List (Integer between 0 and 4294967295),
-   tvar-types : List CodexType
+   tvar-types : List CodexType,
+   expected : CodexType
   }
 
  An empty list literal reaches the IR without a concrete element type,
@@ -467,6 +468,18 @@ Section: Constructor Map
    else let f = list-at fields i
    in if f.name.value == fieldname then zig-atype-ll-elem (f.type-expr)
       else zig-field-ll-scan fields (i + 1) fieldname
+
+ The callee's declared parameter type, translated through whatever
+ bindings this call resolved -- a declaration read in the caller names the
+ callee's type variables until it is substituted.
+
+  zig-callee-param-type : ZigCtx, Text, Integer -> CodexType
+  zig-callee-param-type (ctx) (fname) (i) =
+   let di = zig-find-irdef (ctx.irdefs) 0 fname
+   in if di < 0 then VoidTy
+   else let d = list-at (ctx.irdefs) di
+   in if i >= list-length (d.params) then VoidTy
+      else zig-subst-all ((list-at (d.params) i).type-val) ctx 0
 
   zig-param-ll-elem : ZigCtx, Text, Integer -> Text
   zig-param-ll-elem (ctx) (fname) (argi) =
@@ -639,6 +652,7 @@ Section: Builtin Emitter
     ZigBuiltinEmitter { name = "list-at", emit = \args ctx d ty -> "cx_list_at(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ", " & emit-zig-expr (list-at args 1) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "list-push", emit = \args ctx d ty -> "cx_ll_push(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ", " & emit-zig-expr (list-at args 1) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "list-insert-at", emit = \args ctx d ty -> "cx_ll_insert_at(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ", " & emit-zig-expr (list-at args 1) ctx (d + 1) & ", " & emit-zig-expr (list-at args 2) ctx (d + 1) & ")" },
+    ZigBuiltinEmitter { name = "text-compare", emit = \args ctx d ty -> "cx_text_compare(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ", " & emit-zig-expr (list-at args 1) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "char-to-text", emit = \args ctx d ty -> "cx_char_to_text(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "__linked-list-empty", emit = \args ctx d ty -> "cx_ll_empty(" & zig-ll-elem ty & ")" },
     ZigBuiltinEmitter { name = "__linked-list-push", emit = \args ctx d ty -> "cx_ll_push(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ", " & emit-zig-expr (list-at args 1) ctx (d + 1) & ")" },
@@ -726,7 +740,8 @@ Section: Name Mapping
     renamed-from = from,
     renamed-to = to,
     tvar-ids = ctx.tvar-ids,
-    tvar-types = ctx.tvar-types
+    tvar-types = ctx.tvar-types,
+    expected = ctx.expected
    }
    in zig-push-lambda-renames ctx2 params d (i + 1)
 
@@ -812,7 +827,7 @@ Section: Type Definition Emission
      if recmut
      then "const " & zig-sanitize (name.value) & "S = struct {\n" & emit-zig-record-fields fields 0 & "};\n"
       & "const " & zig-sanitize (name.value) & " = *" & zig-sanitize (name.value) & "S;\n\n"
-     else emit-zig-record-type (name.value) fields
+     else emit-zig-record-type (name.value) fields tparams
     is AVariantTypeDef (name) (tparams) (ctors) (s) ->
      emit-zig-sum-type (name.value) ctors tparams
     is AUnitTypeDef (name) (unitbase) (s) -> ""
@@ -896,9 +911,17 @@ Section: Type Definition Emission
    else if i == list-length fs - 1 then emit-zig-atype (list-at fs i)
    else emit-zig-atype (list-at fs i) & ", " & emit-zig-ctor-payloads fs (i + 1)
 
-  emit-zig-record-type : Text, List ARecordFieldDef -> Text
-  emit-zig-record-type (name) (fields) =
-   "const " & zig-sanitize name & " = struct {\n" & emit-zig-record-fields fields 0 & "};\n\n"
+ A record quantified over type variables becomes a function from types to
+ a type, exactly as a variant does. emit-zig-sum-type learned this when
+ generics went in; this did not, so SortPartition emitted as a plain
+ struct holding a List of an undeclared `a`.
+
+  emit-zig-record-type : Text, List ARecordFieldDef, List Name -> Text
+  emit-zig-record-type (name) (fields) (tparams) =
+   if list-length tparams > 0
+   then "fn " & zig-sanitize name & "(" & zig-tparam-params tparams 0 & ") type {\n    return struct {\n"
+      & emit-zig-record-fields fields 0 & "    };\n}\n\n"
+   else "const " & zig-sanitize name & " = struct {\n" & emit-zig-record-fields fields 0 & "};\n\n"
 
   emit-zig-record-fields : List ARecordFieldDef, Integer -> Text
   emit-zig-record-fields (fields) (i) =
@@ -989,7 +1012,7 @@ Section: Expression Emission
     is IrName (n) (ty) (sp) -> emit-zig-name n ty ctx d
     is IrBinary (op) (l) (r) (ty) (sp) -> emit-zig-binary op l r ctx d
     is IrNegate (operand) (nty) (sp) -> "(-" & emit-zig-expr operand ctx (d + 1) & ")"
-    is IrIf (c) (t) (el) (ty) (sp) -> "(if (" & emit-zig-expr c ctx (d + 1) & ") " & emit-zig-if-branch t ty el ctx d & " else " & emit-zig-if-branch el ty t ctx d & ")"
+    is IrIf (c) (t) (el) (ty) (sp) -> "(if (" & emit-zig-expr c ctx (d + 1) & ") " & emit-zig-if-branch t ty el (zig-expect ctx ty) d & " else " & emit-zig-if-branch el ty t (zig-expect ctx ty) d & ")"
     is IrLet (name) (ty) (val) (body) (sp) ->
      if zig-is-seq-name name then zig-label d & ": { _ = " & emit-zig-expr val ctx (d + 1) & "; break :" & zig-label d & " " & emit-zig-expr body ctx (d + 1) & "; }"
      else if zig-occurs body name then zig-label d & ": { const " & zig-sanitize name & " = " & emit-zig-expr val ctx (d + 1) & "; break :" & zig-label d & " " & emit-zig-expr body ctx (d + 1) & "; }"
@@ -997,7 +1020,7 @@ Section: Expression Emission
     is IrApply (f) (a) (ty) (sp) -> emit-zig-apply e ctx d
     is IrLambda (params) (body) (ty) (sp) -> zig-lambda-closure params body ty ctx d
     is IrList (elems) (ty) (sp) -> emit-zig-list elems ty ctx d
-    is IrMatch (scrut) (branches) (ty) (sp) -> emit-zig-match scrut branches ctx d
+    is IrMatch (scrut) (branches) (ty) (sp) -> emit-zig-match scrut branches ctx d ty
     is IrAct (stmts) (ty) (sp) -> emit-zig-act stmts ctx d (zig-type-is-void ty)
     is IrHandle (eff) (body) (clauses) (ty) (sp) -> emit-zig-expr body ctx (d + 1)
     is IrWithTimeout (secs) (effs) (scopes) (body) (ty) (sp) -> emit-zig-expr body ctx (d + 1)
@@ -1123,7 +1146,9 @@ Section: Lambda and List Helpers
    let annotated = zig-ll-elem-opt ty
    in let et = if text-length annotated > 0 then annotated
       else if list-length elems > 0 then emit-zig-type (zig-expr-type (list-at elems 0))
-      else "@compileError(\"zig plug: no element type for this empty list\")"
+      else let fromctx = zig-ll-elem-opt (ctx.expected)
+       in if text-length fromctx > 0 then fromctx
+          else "@compileError(\"zig plug: no element type for this empty list\")"
    in if list-length elems == 0 then "cx_ll_empty(" & et & ")"
       else "cx_ll_of(" & et & ", &[_]" & et & "{ " & emit-zig-list-elems elems 0 ctx d & " })"
 
@@ -1191,20 +1216,49 @@ Section: Match Emission
    let n = zig-variant-ctor-count (ctx.typedefs) 0 (zig-type-name-of ty)
    in if n == 0 then False else zig-count-ctor-pats branches 0 >= n
 
-  emit-zig-match : IRExpr, List IRBranch, ZigCtx, Integer -> Text
-  emit-zig-match (scrut) (branches) (ctx) (d) =
-   let ex = zig-match-exhaustive ctx (zig-expr-type scrut) branches
-   in "switch (" & emit-zig-expr scrut ctx (d + 1) & zig-match-deref ctx (zig-expr-type scrut) & ") { " & emit-zig-match-arms branches 0 ctx d ex & " }"
+ Every arm of a match has the match's type, so an empty list in one reads
+ it off the match -- the fifth context an empty list can learn from, after
+ a record field, a callee parameter, a constructor payload and an if arm.
 
-  emit-zig-match-arms : List IRBranch, Integer, ZigCtx, Integer, Boolean -> Text
-  emit-zig-match-arms (branches) (i) (ctx) (d) (ex) =
+  emit-zig-match : IRExpr, List IRBranch, ZigCtx, Integer, CodexType -> Text
+  emit-zig-match (scrut) (branches) (ctx) (d) (mty0) =
+   let mty = if text-length (zig-ll-elem-opt mty0) > 0 then mty0
+      else zig-arms-list-type branches 0 mty0
+   in let ex = zig-match-exhaustive ctx (zig-expr-type scrut) branches
+   in "switch (" & emit-zig-expr scrut ctx (d + 1) & zig-match-deref ctx (zig-expr-type scrut) & ") { " & emit-zig-match-arms branches 0 ctx d ex mty & " }"
+
+  emit-zig-match-arms : List IRBranch, Integer, ZigCtx, Integer, Boolean, CodexType -> Text
+  emit-zig-match-arms (branches) (i) (ctx) (d) (ex) (mty) =
    if i == list-length branches then ""
    else let b = list-at branches i
-   in emit-zig-match-arm (b.pattern) (b.body) ctx d ex & emit-zig-match-arms branches (i + 1) ctx d ex
+   in emit-zig-match-arm (b.pattern) (b.body) (zig-expect ctx mty) d ex mty & emit-zig-match-arms branches (i + 1) ctx d ex mty
 
  Constructor arms bind payloads: one field binds by name directly; a
  tuple payload binds `_p<d>` and unpacks into consts inside a labeled
  block so the arm body sees its pattern variables.
+
+ A match's own type is not always resolved -- here the switch is the else
+ arm of an if, and the if carries the type. The arms are all the same type
+ as each other, so an arm that is not an empty list answers for the ones
+ that are. Same trick the if branches use on each other.
+
+  zig-arms-list-type : List IRBranch, Integer, CodexType -> CodexType
+  zig-arms-list-type (branches) (i) (fallback) =
+   if i >= list-length branches then fallback
+   else let b = list-at branches i
+   in if zig-is-empty-list (b.body) then zig-arms-list-type branches (i + 1) fallback
+   else let t = zig-expr-type (b.body)
+   in if text-length (zig-ll-elem-opt t) > 0 then t
+      else zig-arms-list-type branches (i + 1) fallback
+
+  emit-zig-arm-body : IRExpr, CodexType, ZigCtx, Integer -> Text
+  emit-zig-arm-body (body) (mty) (ctx) (d) =
+   if zig-is-empty-list body
+   then let elem = zig-ll-elem-opt mty
+    in let elem2 = if text-length elem > 0 then elem else zig-ll-elem-opt (ctx.expected)
+    in if text-length elem2 > 0 then "cx_ll_empty(" & elem2 & ")"
+       else emit-zig-expr body ctx (d + 1)
+   else emit-zig-expr body ctx (d + 1)
 
   zig-pat-is-catch-all : IRPat -> Boolean
   zig-pat-is-catch-all (pat) =
@@ -1213,14 +1267,15 @@ Section: Match Emission
     is IrWildPat (sp) -> True
     is otherwise -> False
 
-  emit-zig-match-arm : IRPat, IRExpr, ZigCtx, Integer, Boolean -> Text
-  emit-zig-match-arm (pat) (body) (ctx) (d) (ex) =
-   if ex & zig-pat-is-catch-all pat then ""
+  emit-zig-match-arm : IRPat, IRExpr, ZigCtx, Integer, Boolean, CodexType -> Text
+  emit-zig-match-arm (pat) (body0) (ctx) (d) (ex) (mty) =
+   let body = body0
+   in if ex & zig-pat-is-catch-all pat then ""
    else when pat
-    is IrLitPat (text) (ty) (sp) -> text & " => " & emit-zig-expr body ctx (d + 1) & ", "
+    is IrLitPat (text) (ty) (sp) -> text & " => " & emit-zig-arm-body body mty ctx d & ", "
     is IrCtorPat (name) (subs) (ty) (sp) ->
      let nsubs = list-length subs
-     in if nsubs == 0 then "." & zig-sanitize name & " => " & emit-zig-expr body ctx (d + 1) & ", "
+     in if nsubs == 0 then "." & zig-sanitize name & " => " & emit-zig-arm-body body mty ctx d & ", "
      else if nsubs == 1 then
       let binder = zig-pat-binder (list-at subs 0) 0
       in if (binder == "_") | (zig-occurs body binder == False)
@@ -1405,6 +1460,26 @@ Section: Apply Emission
     is EffectfulTy (e) (s) (inner) -> zig-tvar-in-fun-type id p r inner
     is otherwise -> VoidTy
 
+ Every construct that knows what type its children must have says so, and
+ an empty list reads it. That is the whole mechanism: an empty list can
+ never answer for itself, so instead of asking each site to look the answer
+ up its own way, the site that knows tells the site that needs.
+
+  zig-expect : ZigCtx, CodexType -> ZigCtx
+  zig-expect (ctx) (ty) =
+   ZigCtx {
+    arities = ctx.arities,
+    ctors = ctx.ctors,
+    mutables = ctx.mutables,
+    typedefs = ctx.typedefs,
+    irdefs = ctx.irdefs,
+    renamed-from = ctx.renamed-from,
+    renamed-to = ctx.renamed-to,
+    tvar-ids = ctx.tvar-ids,
+    tvar-types = ctx.tvar-types,
+    expected = ty
+   }
+
   zig-subst-all : CodexType, ZigCtx, Integer -> CodexType
   zig-subst-all (ty) (ctx) (i) =
    if i >= list-length (ctx.tvar-ids) then ty
@@ -1425,7 +1500,8 @@ Section: Apply Emission
     renamed-from = ctx.renamed-from,
     renamed-to = ctx.renamed-to,
     tvar-ids = (ctx.tvar-ids) & [id],
-    tvar-types = (ctx.tvar-types) & [bound]
+    tvar-types = (ctx.tvar-types) & [bound],
+    expected = ctx.expected
    }
    in zig-bind-tvars ctx2 d ids (i + 1) args resty
 
@@ -1560,11 +1636,7 @@ Section: Apply Emission
   emit-zig-call-args (fname) (args) (ctx) (d) (i) =
    if i == list-length args then ""
    else let a = list-at args i
-   in let one = if zig-is-empty-list a
-      then let elem = zig-param-ll-elem ctx fname i
-       in if text-length elem > 0 then "cx_ll_empty(" & elem & ")"
-          else emit-zig-expr a ctx (d + 1)
-      else emit-zig-expr a ctx (d + 1)
+   in let one = emit-zig-expr a (zig-expect ctx (zig-callee-param-type ctx fname i)) (d + 1)
    in if i == list-length args - 1 then one
       else one & ", " & emit-zig-call-args fname args ctx d (i + 1)
 
@@ -1578,6 +1650,18 @@ Section: Apply Emission
  holds, alongside a record field decl and a callee's parameter. The
  declared field type is on the variant's ctor, so the ctor being applied
  names it.
+
+ A constructor payload's declared field type is an ATypeExpr rather than a
+ CodexType, so the expectation is carried as text -- the one place the
+ mechanism cannot use zig-expect and says why.
+
+  emit-zig-ctor-arg : ZigCtorEntry, IRExpr, ZigCtx, Integer, Integer -> Text
+  emit-zig-ctor-arg (c) (a) (ctx) (d) (i) =
+   if zig-is-empty-list a
+   then let elem = zig-ctor-ll-elem ctx (c.type-name) (c.ctor-name) i
+    in if text-length elem > 0 then "cx_ll_empty(" & elem & ")"
+       else emit-zig-expr a ctx (d + 1)
+   else emit-zig-expr a ctx (d + 1)
 
   zig-ctor-ll-elem : ZigCtx, Text, Text, Integer -> Text
   zig-ctor-ll-elem (ctx) (tyname) (ctorname) (argi) =
@@ -1605,11 +1689,7 @@ Section: Apply Emission
   emit-zig-ctor-args (c) (args) (ctx) (d) (i) =
    if i == list-length args then ""
    else let a = list-at args i
-   in let one = if zig-is-empty-list a
-      then let elem = zig-ctor-ll-elem ctx (c.type-name) (c.ctor-name) i
-       in if text-length elem > 0 then "cx_ll_empty(" & elem & ")"
-          else emit-zig-expr a ctx (d + 1)
-      else emit-zig-expr a ctx (d + 1)
+   in let one = emit-zig-ctor-arg c a ctx d i
    in if i == list-length args - 1 then one
       else one & ", " & emit-zig-ctor-args c args ctx d (i + 1)
 
@@ -1638,6 +1718,11 @@ Section: Definition Emission
  When it is not -- map-list-loop again -- the body's own type is what the
  definition actually returns, and it is the only source left.
 
+  zig-def-return-type : IRDef -> CodexType
+  zig-def-return-type (d) =
+   let peeled = zig-peel-return (d.type-val) (list-length (d.params))
+   in if zig-is-unmapped (emit-zig-type peeled) then zig-expr-type (d.body) else peeled
+
   zig-def-return-text : IRDef -> Text
   zig-def-return-text (d) =
    let peeled = emit-zig-type (zig-peel-return (d.type-val) (list-length (d.params)))
@@ -1660,6 +1745,45 @@ Section: Definition Emission
    if i >= list-length params then acc
    else zig-def-param-tvars params (i + 1) (zig-tvar-ids ((list-at params i).type-val) acc)
 
+ Zig forbids a parameter from shadowing a top-level declaration, and codex
+ does not: NameResolver has a global `builtins` and build-all-names-scope
+ takes a parameter called `builtins`. This is the same problem the lambda
+ parameters had, one scope out, so it takes the same answer -- rename the
+ parameter and carry the rename into the body.
+
+ The collision is with definitions, which is what emit-zig-defs writes at
+ the top level. Constructors and type names live there too, and a param
+ colliding with one of those would need the same treatment; nothing has
+ hit it yet, and the marker would not catch it because it is a name error
+ rather than a type error.
+
+  zig-param-shadows : ZigCtx, Text -> Boolean
+  zig-param-shadows (ctx) (n) =
+   zig-find-irdef (ctx.irdefs) 0 n >= 0
+
+  zig-def-param-name : ZigCtx, Text -> Text
+  zig-def-param-name (ctx) (n) =
+   if zig-param-shadows ctx n then "_arg_" & zig-sanitize n else zig-sanitize n
+
+  zig-push-param-renames : ZigCtx, List IRParam, Integer -> ZigCtx
+  zig-push-param-renames (ctx) (params) (i) =
+   if i >= list-length params then ctx
+   else let nm = (list-at params i).name
+   in if zig-param-shadows ctx nm == False then zig-push-param-renames ctx params (i + 1)
+   else let ctx2 = ZigCtx {
+    arities = ctx.arities,
+    ctors = ctx.ctors,
+    mutables = ctx.mutables,
+    typedefs = ctx.typedefs,
+    irdefs = ctx.irdefs,
+    renamed-from = (ctx.renamed-from) & [nm],
+    renamed-to = (ctx.renamed-to) & ["_arg_" & zig-sanitize nm],
+    tvar-ids = ctx.tvar-ids,
+    tvar-types = ctx.tvar-types,
+    expected = ctx.expected
+   }
+   in zig-push-param-renames ctx2 params (i + 1)
+
   zig-comptime-params : List (Integer between 0 and 4294967295), Integer -> Text
   zig-comptime-params (ids) (i) =
    if i >= list-length ids then ""
@@ -1667,19 +1791,31 @@ Section: Definition Emission
       & zig-comptime-params ids (i + 1)
 
   emit-zig-def : IRDef, ZigCtx -> Text
-  emit-zig-def (d) (ctx) =
+  emit-zig-def (d) (ctx0) =
    if zig-skip-def (d.name) then ""
    else let name = zig-sanitize (d.name)
-   in let params-text = emit-zig-def-params (d.params) 0
+   in let params-text = emit-zig-def-params (d.params) 0 ctx0
    in let tvars = zig-def-tvar-ids d
    in let comptimes = zig-comptime-params tvars 0
    in let all-params = if text-length params-text == 0
       then zig-drop-trailing-comma comptimes
       else comptimes & params-text
    in let ret = zig-def-return-text d
+   in let ctx = ZigCtx {
+    arities = ctx0.arities,
+    ctors = ctx0.ctors,
+    mutables = ctx0.mutables,
+    typedefs = ctx0.typedefs,
+    irdefs = ctx0.irdefs,
+    renamed-from = ctx0.renamed-from,
+    renamed-to = ctx0.renamed-to,
+    tvar-ids = ctx0.tvar-ids,
+    tvar-types = ctx0.tvar-types,
+    expected = zig-def-return-type d
+   }
    in "fn " & name & "(" & all-params & ") " & ret & " {\n"
     & emit-zig-param-discards (d.params) 0 (d.body)
-    & "    return " & emit-zig-expr (d.body) ctx 0 & ";\n}\n\n"
+    & "    return " & emit-zig-expr (d.body) (zig-push-param-renames ctx (d.params) 0) 0 & ";\n}\n\n"
 
  A parameter the body never mentions is a hard error in zig, not a warning,
  so a definition that ignores an argument needs the discard written out.
@@ -1693,13 +1829,13 @@ Section: Definition Emission
       else "    _ = " & zig-sanitize (p.name) & ";\n"
    in line & emit-zig-param-discards params (i + 1) body
 
-  emit-zig-def-params : List IRParam, Integer -> Text
-  emit-zig-def-params (params) (i) =
+  emit-zig-def-params : List IRParam, Integer, ZigCtx -> Text
+  emit-zig-def-params (params) (i) (ctx) =
    if i == list-length params then ""
    else let p = list-at params i
-   in let one = zig-sanitize (p.name) & ": " & emit-zig-type (p.type-val)
+   in let one = zig-def-param-name ctx (p.name) & ": " & emit-zig-type (p.type-val)
    in if i == list-length params - 1 then one
-   else one & ", " & emit-zig-def-params params (i + 1)
+   else one & ", " & emit-zig-def-params params (i + 1) ctx
 
  Assembling the output has the same hazard as escaping it: joining N pieces
  with a right-recursive `&` copies every piece it has not reached yet, so
@@ -1759,7 +1895,8 @@ Section: Chapter Emission
    & "fn cx_ll_of(comptime T: type, vs: []const T) *CxList(T) {\n    const l = cx_ll_empty(T);\n    l.items.appendSlice(std.heap.page_allocator, vs) catch @panic(\"oom\");\n    return l;\n}\n"
    & "fn cx_ll_concat(a: anytype, b: @TypeOf(a)) @TypeOf(a) {\n    const c = cx_new(@TypeOf(a.*){ .items = .empty });\n    c.items.appendSlice(std.heap.page_allocator, a.items.items) catch @panic(\"oom\");\n    c.items.appendSlice(std.heap.page_allocator, b.items.items) catch @panic(\"oom\");\n    return c;\n}\n"
    & "fn cx_ll_cons(v: anytype, l: anytype) @TypeOf(l) {\n    const c = cx_new(@TypeOf(l.*){ .items = .empty });\n    c.items.append(std.heap.page_allocator, v) catch @panic(\"oom\");\n    c.items.appendSlice(std.heap.page_allocator, l.items.items) catch @panic(\"oom\");\n    return c;\n}\n"
-   & "fn cx_ll_insert_at(l: anytype, i: i64, v: anytype) @TypeOf(l) {\n    const c = cx_new(@TypeOf(l.*){ .items = .empty });\n    c.items.appendSlice(std.heap.page_allocator, l.items.items) catch @panic(\"oom\");\n    c.items.insert(std.heap.page_allocator, @intCast(i), v) catch @panic(\"oom\");\n    return c;\n}\n"
+   & "fn cx_ll_insert_at(l: anytype, i: i64, v: anytype) @TypeOf(l) {\n    l.items.insert(std.heap.page_allocator, @intCast(i), v) catch @panic(\"oom\");\n    return l;\n}\n"
+   & "fn cx_text_compare(a: []const u8, b: []const u8) i64 {\n    return switch (std.mem.order(u8, a, b)) { .lt => -1, .eq => 0, .gt => 1 };\n}\n"
    & "fn cx_char_to_text(c: i64) []const u8 {\n    const b = std.heap.page_allocator.alloc(u8, 1) catch @panic(\"oom\");\n    b[0] = @intCast(c);\n    return b;\n}\n"
    & "fn cx_list_len(l: anytype) i64 {\n    return @intCast(l.items.items.len);\n}\n"
    & "fn cx_list_at(l: anytype, i: i64) @TypeOf(l.items.items[0]) {\n    return l.items.items[@intCast(i)];\n}\n"
@@ -1776,7 +1913,7 @@ Section: Chapter Emission
    & "fn cx_text_starts_with(s: []const u8, p: []const u8) bool {\n    return std.mem.startsWith(u8, s, p);\n}\n"
    & "fn cx_text_contains(h: []const u8, n: []const u8) bool {\n    return std.mem.indexOf(u8, h, n) != null;\n}\n"
    & "fn cx_text_concat_list(l: anytype) []const u8 {\n    var out = std.ArrayListUnmanaged(u8).empty;\n    for (l.items.items) |p| out.appendSlice(std.heap.page_allocator, p) catch @panic(\"oom\");\n    return out.items;\n}\n"
-   & "fn cx_list_set_at(l: anytype, i: i64, v: anytype) @TypeOf(l) {\n    const c = cx_new(@TypeOf(l.*){ .items = .empty });\n    c.items.appendSlice(std.heap.page_allocator, l.items.items) catch @panic(\"oom\");\n    c.items.items[@intCast(i)] = v;\n    return c;\n}\n"
+   & "fn cx_list_set_at(l: anytype, i: i64, v: anytype) @TypeOf(l) {\n    l.items.items[@intCast(i)] = v;\n    return l;\n}\n"
    & "// Text is CCE here, so a decimal digit is byte 3 + d and minus is 73;\n// parsing this as ASCII would silently read zero.\n"
    & "fn cx_text_to_integer(s: []const u8) i64 {\n    var acc: i64 = 0;\n    var neg = false;\n    for (s, 0..) |b, i| {\n        if (i == 0 and b == 73) { neg = true; continue; }\n        if (b < 3 or b > 12) continue;\n        acc = acc * 10 + @as(i64, b - 3);\n    }\n    return if (neg) -acc else acc;\n}\n"
    & "fn cx_text_split(s: []const u8, sep: []const u8) *CxList([]const u8) {\n    const out = cx_ll_empty([]const u8);\n    if (sep.len == 0) return out;\n    var start: usize = 0;\n    while (std.mem.indexOfPos(u8, s, start, sep)) |p| {\n        _ = cx_ll_push(out, s[start..p]);\n        start = p + sep.len;\n    }\n    _ = cx_ll_push(out, s[start..]);\n    return out;\n}\n"
@@ -1799,7 +1936,8 @@ Section: Chapter Emission
     renamed-from = [],
     renamed-to = [],
     tvar-ids = [],
-    tvar-types = []
+    tvar-types = [],
+    expected = VoidTy
    }
    in let types-text = emit-zig-type-defs type-defs 0
    in let defs-text = emit-zig-defs (m.defs) 0 ctx

--- a/codex/plugs/zig/ZigEmitter.codex
+++ b/codex/plugs/zig/ZigEmitter.codex
@@ -1039,6 +1039,19 @@ Section: Expression Emission
    if i >= list-length fs then False
    else zig-occurs ((list-at fs i).value) n | zig-occurs-fields fs (i + 1) n
 
+ A handled effect emits its body and NOTHING ELSE, which is right only
+ while there are no clauses to run: a handle with clauses that emits just
+ its body is a different program that compiles, the same trap IrVecPat set
+ when an unimplemented pattern rendered as a catch-all. With clauses it
+ refuses by name instead. This one is latent -- no subject in the ladder
+ reaches an effect handler yet -- and it is written down now because the
+ cost of finding it later is a wrong answer rather than an error.
+
+ IrWithTimeout, IrFork and IrAwait below drop a timeout, a fork and a wait
+ the same way. They are left alone deliberately: running the body inline is
+ a defensible reading of each for a single-threaded target, where dropping
+ a clause that was written to run is not.
+
   emit-zig-expr : IRExpr, ZigCtx, Integer -> Text
   emit-zig-expr (e) (ctx) (d) =
    if d >= zig-max-depth then "undefined"
@@ -1061,7 +1074,7 @@ Section: Expression Emission
     is IrList (elems) (ty) (sp) -> emit-zig-list elems ty ctx d
     is IrMatch (scrut) (branches) (ty) (sp) -> emit-zig-match scrut branches ctx d ty
     is IrAct (stmts) (ty) (sp) -> emit-zig-act stmts ctx d (zig-type-is-void ty)
-    is IrHandle (eff) (body) (clauses) (ty) (sp) -> emit-zig-expr body ctx (d + 1)
+    is IrHandle (eff) (body) (clauses) (ty) (sp) -> if list-length clauses == 0 then emit-zig-expr body ctx (d + 1) else "@compileError(\"zig plug: effect handlers not supported\")"
     is IrWithTimeout (secs) (effs) (scopes) (body) (ty) (sp) -> emit-zig-expr body ctx (d + 1)
     is IrRecord (name) (fields) (ty) (sp) -> emit-zig-record name fields ctx d (zig-ctor-type-args ty)
     is IrFieldAccess (rec) (field) (ty) (sp) -> emit-zig-expr rec ctx (d + 1) & "." & zig-field-name field

--- a/deck-record-repro/PLUG_IR_TRANSPORT.md
+++ b/deck-record-repro/PLUG_IR_TRANSPORT.md
@@ -1,0 +1,174 @@
+# net-recv-raw drops the last byte of every odd-length frame
+
+## What we recommend
+
+1. **Take the fix.** It is in this PR, one commit, two added instructions
+   in `emit-net-recv-raw-helper`. We could not compile it here (see
+   below), so please build before trusting it.
+2. **Look at receive-side TCP checksums.** A byte substituted inside a
+   TCP payload reached the parser with nothing objecting. Whatever the
+   reason, that is the layer that should have caught this, and it would
+   have turned two days of archaeology into one dropped segment and a
+   retransmit.
+3. **Keep the `codex-vm` pad.** It stops being load bearing once the
+   guest is fixed, but it costs nothing and it is correct.
+4. **Do not certify a plug transfer by comparing outputs.** See "A
+   corrupted byte is not always a visible one" below. This one surprised
+   us and it invalidated one of our own measurements.
+
+## The defect
+
+`emit-net-recv-raw-helper` reads the frame body out of the NE2000 with a
+word-granular `rep insw`:
+
+```
+   pop rcx          ; rcx = frame body length, in BYTES
+   shr rcx, 1       ; -> word count, rounding DOWN
+   cld
+   rep insw         ; move rcx words into the caller's buffer
+```
+
+When the body length is odd, `rep insw` moves `len - 1` bytes and the
+final byte is never read from the NIC. The helper still returns `len`, so
+`ne2k-read-from-buf` reads all `len` bytes back out of the fixed buffer
+at 33056. That buffer is never cleared between frames, so the last byte
+of an odd-length frame comes back as **whatever the previous frame left
+at that buffer offset**: a real, recent byte from the same stream. It is
+always plausible, it never trips a parser, and nothing anywhere reports
+it.
+
+The send path already compensates. `ne2k-send-frame` in
+`codex/os/kernel/Ne2k.codex` pads an odd frame and transmits
+`len + (int-mod len 2)`. TX knows the DMA is word-granular; RX does not.
+
+## The fix
+
+Round the byte count up to even at `st56`, where it is popped and before
+it is pushed back for RBCR. The existing `shr` at `st70` then derives the
+right word count from it, and RBCR agrees with what is actually
+transferred:
+
+```
+   pop rcx                       ; st56, rcx = body length
+   add rcx, 1                    ; 48 83 C1 01   <- added
+   and rcx, -2                   ; 48 83 E1 FE   <- added
+   push rcx                      ; st57, and on into RBCR
+   ...
+   pop rcx                       ; st69
+   shr rcx, 1                    ; st70, now exact
+   rep insw
+```
+
+Safe: the length check above rejects any body over 1536, so an odd body
+is at most 1535 and rounding up transfers 1536, exactly the receive
+buffer's size, still clear of the TX buffer at 34592. The returned length
+is unchanged, so the pad byte is never read back out. Jump patching is
+unaffected, since every label position is a `code-len` snapshot taken
+after the insertion and `patch-jcc-at` computes relative deltas.
+
+**Not compiled here.** The concatenated compiler source is 2.78 MB and
+our QEMU side-channel injects through a 1 MB ring, so we cannot self-host
+on this machine. The change is offered as a diff in the file you own
+rather than as a paragraph in a bug report.
+
+## Why you have never seen it
+
+`codex-vm` compensates. `ne2k_inject_rx` in `tools/codex-vm.c` pads every
+odd frame before it reaches the ring, and names the mechanism exactly:
+
+```c
+/* Pad odd-length frames to even: the guest uses REP INSW (word DMA)
+   which reads frame_len/2 words, truncating the last byte of odd frames.
+   The ip-payload fix uses ip-total-length to ignore the padding byte. */
+```
+
+That went in with Update 30, and `ip-total-length` in
+`codex/os/net/Ethernet.codex` is the guest half of the same
+compensation. Two workarounds, cause untouched. The receive path is
+therefore sound only against an emulator that pads for it: QEMU's
+`ne2k_isa` pads to the 60-byte minimum, like real hardware, but not to
+even. Everything below was measured there.
+
+## Evidence
+
+Twenty-five transfers of a 191 KB IR through the zig plug, wire captured
+each time with `filter-dump`.
+
+**Parity predicts every run.** Taking the frame that carries IR offset
+36863 and asking only whether its body length is odd:
+
+| frame carrying the offset | runs | outcome |
+|---|---|---|
+| odd body (923 bytes) | 11 | corrupt, every time |
+| even body (1270 bytes) | 3 | clean |
+| offset falls mid-frame | 11 | clean |
+
+25 of 25, no exceptions.
+
+**The stale byte is the predicted one.** The corrupting frame has a
+923-byte body, so the untransferred byte is at buffer offset 922. The
+previous frame through that buffer carries byte 2 (a CCE space) there.
+The guest reported 2. The correct byte was 73, a dash, and
+`scan-digits-end` emitted as `fn scan digits_end` -- not valid zig.
+
+**The wire is innocent.** Reassembling the host-to-guest stream from a
+corrupt run's capture yields the IR exactly: 191,126 bytes, no gaps, no
+retransmits, byte 73 delivered correctly.
+
+## One defect, three doses
+
+The stalls and crashes we reported earlier as a "defect family" are the
+same bug. Severity tracks how many odd frames the segmentation produces:
+
+| odd frames | what you see |
+|---|---|
+| 0 | correct output |
+| 1 | one substituted byte: a wrong program, or nothing visible |
+| 33-37 | `!EXC=06`, a crash inside `parse-expr` |
+
+An odd *chunk size* makes nearly every remainder frame odd, which is why
+4097 was singularly bad: 37 and 33 odd frames in two runs, both crashing
+at different RIPs inside `parse-expr` (+3791 and +2680) -- data-dependent,
+the shape of a parser walking into mangled input rather than a fixed bug.
+
+The capture clears the transport in the crash case: the guest ACKed all
+191,132 bytes with zero retransmissions, transfer complete in 0.9s, then
+a 10s gap and the crash. It receives everything and dies parsing it.
+
+The dead stalls did not reproduce against the current plug (chunk 1500,
+three runs, all completed). They were characterised before the linear
+`bytes-to-text` fix. We are retiring the claim rather than restating it.
+
+## A corrupted byte is not always a visible one
+
+Our earlier table recorded chunk 1500 and 3000 as "0 of 4 corrupted".
+That was wrong, and it is the most useful thing we learned by being
+wrong.
+
+Chunk 1500 carries exactly one odd frame every run and still emits
+byte-identical output, because the truncation lands at IR offset 11999
+and turns `int` into `lnt` inside a type expression the emitter never
+consults. We confirmed it by handing the plug an IR with that byte
+changed by hand: identical output.
+
+So a passing output comparison only covers the bytes that reach the
+output. **Only the capture can certify a transfer** -- no host-to-guest
+frame with an odd body. We now do exactly that, one transfer plus a
+proof, instead of the old transfer-twice-and-compare.
+
+## Blind alleys, so nobody walks them again
+
+- **It is not a CCE encoder/decoder bug.** The mangled name looks exactly
+  like a CCE round-trip fault, and that is where we spent the first day.
+  Decoding the IR on disk shows the byte correct; the damage happens on
+  the way in.
+- **It is not the plug's `bytes-to-text`.** That converts in 256-byte
+  chunks and is the obvious suspect. Rebuilt with the chunk changed to
+  200, the corruption still landed at the same offset.
+- **The "256-byte alignment condition" is not a condition.** Every
+  corrupting chunk size we first tried happened to be a multiple of 256.
+  It is a coincidence of the sizes tried.
+- **The site is not a property of the payload.** It moves with the frame
+  layout, which is set by TCP segmentation, which is why host CPU load
+  appeared to change a corruption rate. Nothing here is racy given the
+  frames.

--- a/deck-record-repro/README.md
+++ b/deck-record-repro/README.md
@@ -1,0 +1,365 @@
+# Eight findings: five closed by Update 43, three open
+
+This directory holds the findings and the probes that make them runnable.
+It is discussion material rather than a proposed addition to the tree --
+drop it whenever, or take it; the zig-plug changes in this PR are separate
+and stand on their own.
+
+**Status after Update 43.** Findings 1 through 5 are fixed and this
+document keeps them only as a record of what was asked and what landed.
+Findings 6, 7 and 8 are open. Each closed one is marked at its heading,
+and finding 4's entry is worth a second look: it did not close as a
+one-line cite but as `build/check-subset-cites.ps1`, a gate for the whole
+class it belonged to.
+
+They all came out of one exercise, run as a ladder: for each compiler
+phase, bundle the chapters that implement it into a standalone subject
+with a dump harness, compile it two ways -- seed on bare metal as truth,
+and through the zig plug -- and require the two to agree byte for byte.
+The same oracle discipline as `plug-oracle-test`, with the compiler's own
+source as the subject.
+
+**Eight rungs pass** as of seed F3722EAC: lex, parse, desugar, scope,
+check, lower, text and pingpong. The last two are the point of the
+exercise. `text` emits canonical codex source out of the IR through the
+plug, and `pingpong` compiles that emitted source again and requires the
+second text to equal the first -- a fixed point, reached through the zig
+plug rather than on the metal.
+
+Several of these only appear once a plug carries more payload than plugs
+usually carry, and the later ones only appear once a plug meets code the
+earlier rungs never reached. Nothing here is exotic; it is ordinary code
+meeting a bigger input.
+
+## 1. `net-recv-raw` truncates odd-length frames
+
+**CLOSED in Update 43.** The count is rounded up before it reaches RBCR.
+The follow-on closed too: TCP and IP checksums are now verified on
+receive, and a frame claiming more bytes than it carries is refused.
+
+**Diagnosed, fixed in this PR, not compiled here.** Full write-up:
+`PLUG_IR_TRANSPORT.md`. Read that one first if you read only one.
+
+`emit-net-recv-raw-helper` derives its `rep insw` word count with
+`shr rcx, 1`, which rounds down, so an odd-length frame loses its final
+byte. The helper returns the full length anyway and the receive buffer is
+never cleared, so that byte comes back as whatever the previous frame
+left at the same offset. Silent, plausible, undiagnosed. Severity tracks
+the number of odd frames: one gives a wrong program, 33-37 gives
+`!EXC=06` inside `parse-expr`.
+
+You have compensated for this before -- `ne2k_inject_rx` in
+`tools/codex-vm.c` pads odd frames, with a comment naming the mechanism,
+and `ip-total-length` is the guest half. Both are workarounds; the
+receive path itself was never fixed, so it is sound only against an
+emulator that pads for it. QEMU's `ne2k_isa` does not, and neither would
+real hardware.
+
+**Also worth your time:** nothing verifies receive-side TCP checksums. A
+substituted payload byte reached the parser unchallenged.
+
+## 2. The `deck-record` intercept fires on the name alone
+
+**CLOSED in Update 43.** The intercept compares the chapter that defined
+`deck-record` instead of matching the bare name.
+
+**Reproducible, undecided -- we did not want to guess your intent.**
+
+The x86-64 emitter intercepts any 1-argument call literally named
+`deck-record` (`emit-apply` in
+`codex/compiler/Emit/X86_64Compound.codex`) and emits `__deck-enter` /
+evaluate-arg / `__deck-exit` instead of calling the function. In a unit
+that never runs the compiler opening's phase-allocator initialization,
+that corrupts allocator state and the program later reads garbage where a
+pointer should be. Reproduces on the Update 40 and Update 41 seeds. The
+decisive control: renaming the identity function to `my-id`,
+byte-identical otherwise, passes.
+
+`PlugTypes.codex` ships `deck-record : a -> a` so plug bundles
+type-check outside the kernel, but the intercept fires on the name
+regardless of who defined it -- so every plug kernel appears to execute
+uninitialized deck enter/exit sequences today. The zig plug passes its
+oracle anyway; our lexer subject died deterministically, which can only
+be allocation-pattern luck.
+
+Two contracts are possible and we did not want to pick one for you:
+either units outside the compiler proper must initialize the phase
+allocator (making the `PlugTypes` stub a trap), or `deck-record` outside
+the compiler should degrade to a true identity (making the by-name
+intercept want a guard -- perhaps firing only when the resolved callee is
+the PhaseAllocator chapter's own def).
+
+Each probe is self-contained, no cites, no other chapters. Compile with
+`build/compile.ps1 -Src <file> -Out <out>.cdx` and run the cdx.
+
+| file | deck-record | expected |
+|---|---|---|
+| `repro-crash.codex` | defined as `a -> a` identity, called at two sites | **page fault** (`!EXC` in `__linked_list_to_list`, garbage list pointer) |
+| `control-renamed.codex` | byte-identical, every `deck-record` renamed `my-id` | passes: `toks 2` / `errs 0` |
+| `probe-site-record.codex` | kept only around the record construction | page fault |
+| `probe-site-ctor.codex` | kept only around nullary-ctor arguments | page fault |
+| `probe-deck-init.codex` | as repro, plus `__deck-set __heap-save` first | still faults -- base init alone is not the fix |
+| `probe-seeded-signal.codex` | none (control shape) | `toks 2` / `errs 1` / `e0 42` |
+
+The shape is distilled from `Syntax/Lexer.codex` (`tokenize-collect`): a
+state record threaded through a recursive collector via a variant
+payload, with a LinkedList field read at the end.
+`probe-seeded-signal.codex` is the honest-signal template -- a probe whose
+expected output is an empty list cannot tell "correct" from "the misread
+slot happened to hold zero", so it seeds 42 and demands it back.
+
+## 3. `bytes-to-text` is O(n^2) in 42 of 44 plugs
+
+**CLOSED in Update 43, and generalised past what was asked.** Rather than
+fixing the copies, `PlugTypes` now holds the one linear definition every
+plug shares.
+
+**Fixed for the zig plug in this PR. The other 41 are untouched and will
+hit the same wall at the same scale.**
+
+Not a new discovery, and that is the point: `CSharpPlug.codex` and
+`RecheckPlug.codex` already carry the linear version, with a comment
+recording that the old accumulator "hung on the ~9.7MB compiler IR before
+the plug emitted anything". The fix never propagated. The remaining
+plugs still concatenate onto an accumulator per chunk, which copies the
+accumulator every time.
+
+For a 1.18 MB IR that is ~2.7 GB of allocation against a ~3 GB heap, so
+the zig plug printed `OUT OF MEMORY` and emitted nothing.
+
+One trap for anyone tempted by a smaller change: the 256-byte chunk is
+deliberate. The inner loop is quadratic too, so cost is
+`N^2/2C + N*C/2` and 256 sits near the `sqrt(N)` optimum. Raising it
+alone makes things worse -- 8192 measured 4.6 GB and still died.
+
+## 4. TypeChecker uses `capability-names` without citing Capability
+
+**CLOSED in Update 43, by an instrument rather than a cite.** The cite was
+added, and then `build/check-subset-cites.ps1` was written to build every
+chapter against only what it cites -- which caught `BootPaint` borrowing
+`to-unicode` with no cite on its first run. This was the better answer:
+the finding was one instance of a class that only a subset build can see,
+and the class is now measured from the inside.
+
+Small, and only visible from outside a whole-foreword build.
+
+`Types/TypeChecker.codex:3400` is
+
+```
+  capability-vocabulary : List Text
+  capability-vocabulary = capability-names
+```
+
+and `capability-names` is defined in `foreword/core/Capability.codex:198`.
+TypeChecker's cites are Build Settings, Phase Allocator and Tuple. There
+is no cite for Capability.
+
+Nothing is broken in the real build, because the whole foreword is
+present and the name resolves. It surfaces when a subset of the compiler
+is bundled into one unit -- we hit it building a type-check subject for
+the plug oracle, where the bundler carries only what is named or cited and
+the definition was simply absent.
+
+Worth a one-line cite if you want the dependency declared. We mention it
+because it is the same shape as the `deck-record` intercept above:
+something the monolithic build makes invisible, which a subset build
+notices immediately. If you care about the subset property -- and the plug
+bundles are exactly that -- these are the cases that break it.
+
+## 5. An unreachable match arm passes without a word
+
+**CLOSED in Update 43.** CDX2096 refuses an arm nothing can reach.
+
+`Types/TypeCheckerInference.codex:665-666`, in `lint-arg-narrowing`:
+
+```
+   in when declared-param
+    is IntegerTy (lo) (hi) (mode) ->
+     ...
+    is otherwise -> st
+    is otherwise -> st
+```
+
+Two identical catch-alls at the same indentation, in the same `when`. The
+second cannot be reached. It looks like a copy-paste slip rather than
+intent, and it compiles silently.
+
+We scanned the rest of `codex/compiler` for the same shape and this is the
+**only** instance -- 97 other consecutive `is otherwise` pairs are nested
+`when` expressions where an inner catch-all sits directly above an outer
+one, which is legitimate. So the dead arm is a one-off; the diagnostic gap
+is the finding.
+
+**The gap.** Codex says a great deal about far subtler hazards. CDX3005
+spends a paragraph on shadowing a builtin, and rightly -- it explains that
+the danger is cost rather than answer, and cites the Hamt case that sent
+four chapters quadratic. CDX1070 refuses an application that ends at a
+newline and names three ways to fix it. Against that, an arm that can
+never run seems like something you would want to hear about, and nothing
+says anything.
+
+We noticed because zig rejects a second `else` prong outright, so the
+emitted code would not compile. Our plug drops the later catch-all, which
+is safe precisely because it is unreachable -- but the reason we looked was
+a zig error, not a codex one.
+
+Offered as a diagnostic suggestion rather than a bug: an unreachable-arm
+warning would have caught this, and the compiler already has the arm list
+in hand where it checks exhaustiveness.
+
+## 6. `lift-lambdas` exists, and runs after the plug wire is written
+
+`codex/compiler/IR/LambdaLifting.codex` is a complete lambda-lifting pass:
+
+```
+lift-lambdas        : IRChapter, Integer -> IRChapter
+FreeVar             = record { name : Text, type-val : CodexType }
+collect-free-vars   : IRExpr, SkipListText, SkipListText, List FreeVar -> List FreeVar
+build-lifted-params : List FreeVar, List IRParam -> List IRParam
+build-partial-app   : Text, CodexType, List FreeVar, Integer, Integer, SourceSpan -> IRExpr
+```
+
+It has one caller, `opening.codex:831`, in the `cdx-chapter` path with its
+own LIFT phase and deck budget. The plug path is `emit-ir-cce`, which runs
+`compile-frontend-ir` and the named IR pipeline and never reaches it. So
+the IR on the wire still contains lambdas that close over enclosing
+locals, and nothing in the plug interface says so.
+
+**What that cost here.** Zig admits a comptime constant into a nested
+function and refuses a runtime value, so
+`map-list (\a -> resolve-type-expr tdm a) args` cannot be emitted as
+written: `tdm` is a parameter of the definition around it. Getting the
+check rung green meant adding free-variable analysis to the zig emitter --
+a list of the names that are runtime locals of the function being emitted,
+threaded through definition parameters, let bindings, match binders and
+act bindings, intersected with the names each lambda body mentions, with a
+shadowing rule so a lambda parameter that hides an enclosing local is not
+mistaken for a capture.
+
+Almost none of that was necessary. `lift-lambdas` rewrites the use site as
+a **partial application** of the lifted definition, and this plug already
+handled partial application -- `zig-closure-make` builds the environment
+struct and the trampoline, and predates this work. Lifted IR would have
+arrived in a form the plug already knew how to emit.
+
+`FreeVar` also carries `type-val`. The plug has no equivalent, so each
+capture's field type is `@TypeOf` of the value hoisted outside the
+environment struct, because read from within it the enclosing local is
+exactly what zig will not name. That works, but it is a workaround for
+type information this pass already computes.
+
+**Not a request to move it.** Lifting is a pessimization for any target
+that has closures, which is most of them: C#, JS, Haskell, Clojure and
+Elixir all want the lambda to stay a lambda. Running it before the fork
+would make the primary consumers worse to make the tertiary ones simpler.
+Opt-in is the right shape, and the mechanism for that already exists and
+is already used for a plug:
+
+```
+default-ir-pipeline   = ["fold-constants", "inline-leaf-calls", "inline-single-caller"]
+text-plug-ir-pipeline = ["fold-constants"]
+```
+
+`lift-lambdas` is a phase with its own deck budget rather than a
+registrable pass, so this is not a one-line change. But `passes=` is
+already the place where a plug says which transforms it wants.
+
+**The smaller export may be the better one.** This plug never wanted
+lifting. It kept each lambda where it was and only needed to know the
+lambda's free variables and their types. A plug targeting C would want the
+whole pass; a plug targeting a language with closures wants neither;
+this one wanted only the query. `collect-free-vars` is cheaper to expose
+than `lift-lambdas` and serves more targets.
+
+Offered as an observation with a measurement attached rather than a
+request. "Tertiary plugs pay this, that is the deal" is a legitimate
+answer.
+
+## 7. There is no `IRExpr` map or fold, so every plug rewrites the walk
+
+`Types/CodexTypeTree.codex` gives `codex-type-map-children` and
+`codex-type-fold-children`, and consumers build on those instead of
+re-enumerating the type constructors. `IRExpr` has no equivalent, so a plug
+that needs to ask anything about an IR subtree enumerates all 24 of them
+itself. This one has `zig-occurs`, a 24-arm `when` answering "does this
+expression mention this name", used to decide whether a `let` binding is
+dead, whether a parameter needs a discard, and which names a lambda
+captures. Finding 6's free-variable analysis is built on it.
+
+Stated as duplication rather than as a bug, because we went looking for the
+obvious hazard and did not find it. The one arm in `zig-occurs` that does
+not descend fully is `IrHandle`, which skips its clauses -- and this plug
+also drops handler clauses at emission, so the walk is consistent with the
+feature being unimplemented rather than with an oversight. `IrTry` and
+`IrWithTimeout` looked like gaps at first glance and are not: their first
+fields are `Integer`, not `IRExpr`.
+
+So the cost we can demonstrate is only that the walk had to be written, not
+that writing it went wrong. Worth weighing against the fact that the
+precedent for the fix is already in the tree: the type tree got its map and
+fold, and the IR did not.
+
+## 8. passes=text-plug changes the IR's type vocabulary, and nothing says so
+
+`IR/Passes.codex` tells a plug that emits SOURCE to drop the inline passes,
+and says why in so many words:
+
+```
+ A plug that emits SOURCE resolves a call by its name, so a pass that
+ substitutes a body and deletes the call deletes the plug's only handle on
+ it. The inline passes are therefore absent here and must stay absent.
+
+  text-plug-ir-pipeline : List Text
+  text-plug-ir-pipeline = ["fold-constants"]
+```
+
+Good advice, and taking it changes more than which calls survive. It changes
+which TYPE CONSTRUCTORS reach the wire.
+
+`probe-forall-sort.codex` in this directory is the reproducer: bundle it
+with `codex/foreword/core/Sort.codex` and nothing else, compile IR-CCE, and
+read the def. Compile the same `sort-by` inside a large unit under each
+pipeline and the definition's type differs:
+
+```
+default-ir-pipeline    (fn (list (tvar 51)) (fn ... (list (tvar 51))))
+text-plug-ir-pipeline  (forall 51 (fn (list (tvar 51)) (fn ... (list (tvar 51)))))
+```
+
+With the inline passes on, a polymorphic definition arrives already
+specialised and its quantifier is gone. With them off it arrives quantified,
+and `ForAllTy` appears on the wire where the machine-code plugs reading the
+same IR-CCE never see it.
+
+**What it cost us.** This plug handled `ForAllEff`, the effect-level
+quantifier, in eight places, and `ForAllTy` in none -- so a quantified type
+had no arrows to count, could not be peeled to find a return type, and had
+no zig rendering at all. It surfaced as `sort-by` emitted with return type
+`void` around a body returning a list, three phases away from the cause, and
+only because zig objected to the mismatch. Six milestones had passed on the
+default pipeline without ever meeting the constructor.
+
+That is our defect to fix and we have fixed it. The finding is that nothing
+warns a plug author this is coming. The prose above is careful to say the
+inline passes matter to a source plug; it does not mention that following
+the advice widens the type vocabulary the plug must handle. A plug developed
+and tested against the default pipeline is not tested against the IR it will
+actually receive once it does the recommended thing.
+
+Worth a look across the fleet: any plug that emits source, uses
+`text-plug-ir-pipeline`, and has no `ForAllTy` arm has the same hole. The
+symptom is not a crash but a wrong type, which is the kind that travels.
+
+Two smaller notes from the same trail, neither demonstrated to have fired,
+both offered only as things we noticed:
+
+`lower-def` reads a definition's type with `lookup-type-bsearch types rn`,
+which answers `ErrorTy` from three separate paths -- empty list, position
+past the end, name mismatch at the position found -- and never distinguishes
+"no such binding" from "the binding is an error type". A definition that
+silently loses its type is hard to trace back from, as this one was.
+
+`zig-peel-return`'s analogue in any plug has the same shape: peeling N
+arrows off a type with fewer than N returns what is left rather than
+reporting the shortfall. Combined with the above, a missing type becomes a
+plausible wrong type rather than an error.

--- a/deck-record-repro/control-renamed.codex
+++ b/deck-record-repro/control-renamed.codex
@@ -1,0 +1,110 @@
+Chapter: Tokens
+
+Section: Types
+  TokenKind =
+   | EndOfFile
+   | Identifier
+
+  Token = record {
+   kind : TokenKind,
+   source : Text,
+   offset : Integer,
+   length : Integer,
+   line : Integer,
+   column : Integer,
+   file-id : Integer
+  }
+
+Section: MergedLexer
+
+Section: Constants
+Section: Lexer State
+  mutable LexState = record {
+   source : Text,
+   offset : Integer,
+   line : Integer,
+   column : Integer,
+   file-id : Integer,
+   errors : LinkedList Integer,
+   prose-mode : Boolean
+  }
+
+  make-lex-state : Text, Integer, LinkedList Integer -> LexState
+  make-lex-state (src) (fid) (pre-errors) =
+   LexState {
+    source = src,
+    offset = 0,
+    line = 1,
+    column = 1,
+    file-id = fid,
+    errors = pre-errors,
+    prose-mode = False
+   }
+
+  advance-char : LexState -> LexState
+  advance-char (st) =
+   LexState {
+     source = st.source,
+     offset = st.offset + 1,
+     line = st.line,
+     column = st.column + 1,
+     file-id = st.file-id,
+     errors = st.errors,
+     prose-mode = st.prose-mode
+    }
+
+  LexStep =
+   | LexToken (Token) (LexState)
+   | LexEnd
+
+  make-token : TokenKind, Integer, LexState -> Token
+  make-token (kind) (length) (st) =
+   my-id (Token {
+    kind = kind,
+    source = st.source,
+    offset = st.offset,
+    length = length,
+    line = st.line,
+    column = st.column,
+    file-id = st.file-id
+   })
+
+
+Section: Tokenize All
+  LexCollected = record {
+   collected-tokens : LinkedList Token,
+   collected-errors : LinkedList Integer
+  }
+
+Section: MergedLexStubs
+
+ Outside the kernel there are no phase decks; the identity stub mirrors
+ the one PlugTypes.codex carries for the same reason.
+
+Section: Stubs
+  my-id : a -> a
+  my-id (x) = x
+
+Section: MergedTokProbe
+
+  my-scan : LexState -> LexStep
+  my-scan (st) =
+   if st.offset >= 1 then LexEnd
+   else LexToken (make-token (my-id Identifier) 1 st) (advance-char st)
+
+  my-collect : LexState, LinkedList Token, Integer -> LexCollected
+  my-collect (st) (acc) (ceiling) =
+   when my-scan st
+    is LexToken (tok) (next) ->
+     if tok.kind == EndOfFile then LexCollected { collected-tokens = __linked-list-push acc tok, collected-errors = next.errors }
+      else my-collect next (__linked-list-push acc tok) ceiling
+    is LexEnd ->
+     LexCollected { collected-tokens = __linked-list-push acc (make-token (my-id EndOfFile) 0 st), collected-errors = st.errors }
+
+  opening : [Console] Nothing = act
+    let raw = my-collect (make-lex-state "x" 1 (__linked-list-empty 0)) (__linked-list-empty 0) 0
+    in act
+      print-line-uni ("toks " & show (list-length (__linked-list-to-list (raw.collected-tokens))))
+      print-line-uni ("errs " & show (list-length (__linked-list-to-list (raw.collected-errors))))
+    end
+  end

--- a/deck-record-repro/probe-deck-init.codex
+++ b/deck-record-repro/probe-deck-init.codex
@@ -1,0 +1,112 @@
+Chapter: Tokens
+
+Section: Types
+  TokenKind =
+   | EndOfFile
+   | Identifier
+
+  Token = record {
+   kind : TokenKind,
+   source : Text,
+   offset : Integer,
+   length : Integer,
+   line : Integer,
+   column : Integer,
+   file-id : Integer
+  }
+
+Section: MergedLexer
+
+Section: Constants
+Section: Lexer State
+  mutable LexState = record {
+   source : Text,
+   offset : Integer,
+   line : Integer,
+   column : Integer,
+   file-id : Integer,
+   errors : LinkedList Integer,
+   prose-mode : Boolean
+  }
+
+  make-lex-state : Text, Integer, LinkedList Integer -> LexState
+  make-lex-state (src) (fid) (pre-errors) =
+   LexState {
+    source = src,
+    offset = 0,
+    line = 1,
+    column = 1,
+    file-id = fid,
+    errors = pre-errors,
+    prose-mode = False
+   }
+
+  advance-char : LexState -> LexState
+  advance-char (st) =
+   LexState {
+     source = st.source,
+     offset = st.offset + 1,
+     line = st.line,
+     column = st.column + 1,
+     file-id = st.file-id,
+     errors = st.errors,
+     prose-mode = st.prose-mode
+    }
+
+  LexStep =
+   | LexToken (Token) (LexState)
+   | LexEnd
+
+  make-token : TokenKind, Integer, LexState -> Token
+  make-token (kind) (length) (st) =
+   deck-record (Token {
+    kind = kind,
+    source = st.source,
+    offset = st.offset,
+    length = length,
+    line = st.line,
+    column = st.column,
+    file-id = st.file-id
+   })
+
+
+Section: Tokenize All
+  LexCollected = record {
+   collected-tokens : LinkedList Token,
+   collected-errors : LinkedList Integer
+  }
+
+Section: MergedLexStubs
+
+ Outside the kernel there are no phase decks; the identity stub mirrors
+ the one PlugTypes.codex carries for the same reason.
+
+Section: Stubs
+  deck-record : a -> a
+  deck-record (x) = x
+
+Section: MergedTokProbe
+
+  my-scan : LexState -> LexStep
+  my-scan (st) =
+   if st.offset >= 1 then LexEnd
+   else LexToken (make-token (deck-record Identifier) 1 st) (advance-char st)
+
+  my-collect : LexState, LinkedList Token, Integer -> LexCollected
+  my-collect (st) (acc) (ceiling) =
+   when my-scan st
+    is LexToken (tok) (next) ->
+     if tok.kind == EndOfFile then LexCollected { collected-tokens = __linked-list-push acc tok, collected-errors = next.errors }
+      else my-collect next (__linked-list-push acc tok) ceiling
+    is LexEnd ->
+     LexCollected { collected-tokens = __linked-list-push acc (make-token (deck-record EndOfFile) 0 st), collected-errors = st.errors }
+
+  opening : [Console] Nothing = act
+    let deck-base = __heap-save
+    in let deck-init = __deck-set deck-base
+    in let raw = my-collect (make-lex-state "x" 1 (__linked-list-empty 0)) (__linked-list-empty 0) 0
+    in act
+      print-line-uni ("toks " & show (list-length (__linked-list-to-list (raw.collected-tokens))))
+      print-line-uni ("errs " & show (list-length (__linked-list-to-list (raw.collected-errors))))
+    end
+  end

--- a/deck-record-repro/probe-forall-sort.codex
+++ b/deck-record-repro/probe-forall-sort.codex
@@ -1,0 +1,10 @@
+Chapter: ForallSortProbe
+
+Section: Main
+  cmp-int : Integer, Integer -> Integer
+  cmp-int (a) (b) = a - b
+
+  opening : [Console] Nothing = act
+   let xs = [3, 1, 2]
+   in print-line-uni (show (list-at (sort-by xs cmp-int) 0))
+  end

--- a/deck-record-repro/probe-seeded-signal.codex
+++ b/deck-record-repro/probe-seeded-signal.codex
@@ -1,0 +1,71 @@
+Chapter: Seeded
+
+  KKind =
+   | KIdent
+   | KEof
+
+  Tok = record {
+   kind : KKind,
+   source : Text,
+   offset : Integer,
+   length : Integer,
+   line : Integer,
+   column : Integer,
+   file-id : Integer
+  }
+
+  mutable LState = record {
+   source : Text,
+   offset : Integer,
+   line : Integer,
+   column : Integer,
+   file-id : Integer,
+   errors : LinkedList Integer,
+   prose-mode : Boolean
+  }
+
+  LStep =
+   | LTok (Tok) (LState)
+   | LEnd
+
+  LColl = record {
+   c-toks : LinkedList Tok,
+   c-errs : LinkedList Integer
+  }
+
+  mk-state : Text, Integer, LinkedList Integer -> LState
+  mk-state (src) (fid) (pre) =
+   LState { source = src, offset = 0, line = 1, column = 1, file-id = fid, errors = pre, prose-mode = False }
+
+  adv : LState -> LState
+  adv (st) =
+   LState { source = st.source, offset = st.offset + 1, line = st.line, column = st.column + 1, file-id = st.file-id, errors = st.errors, prose-mode = st.prose-mode }
+
+  mk-tok : KKind, Integer, LState -> Tok
+  mk-tok (kind) (length) (st) =
+   Tok { kind = kind, source = st.source, offset = st.offset, length = length, line = st.line, column = st.column, file-id = st.file-id }
+
+  my-scan : LState -> LStep
+  my-scan (st) =
+   if st.offset >= 1 then LEnd
+   else LTok (mk-tok KIdent 1 st) (adv st)
+
+  my-collect : LState, LinkedList Tok, Integer -> LColl
+  my-collect (st) (acc) (ceiling) =
+   when my-scan st
+    is LTok (tok) (next) ->
+     if tok.kind == KEof then LColl { c-toks = __linked-list-push acc tok, c-errs = next.errors }
+      else my-collect next (__linked-list-push acc tok) ceiling
+    is LEnd ->
+     LColl { c-toks = __linked-list-push acc (mk-tok KEof 0 st), c-errs = st.errors }
+
+  opening : [Console] Nothing = act
+    let e0 = __linked-list-push (__linked-list-empty 0) 42
+    in let raw = my-collect (mk-state "x" 1 e0) (__linked-list-empty 0) 0
+    in let errs = __linked-list-to-list (raw.c-errs)
+    in act
+      print-line-uni ("toks " & show (list-length (__linked-list-to-list (raw.c-toks))))
+      print-line-uni ("errs " & show (list-length errs))
+      print-line-uni ("e0 " & show (list-at errs 0))
+    end
+  end

--- a/deck-record-repro/probe-site-ctor.codex
+++ b/deck-record-repro/probe-site-ctor.codex
@@ -1,0 +1,110 @@
+Chapter: Tokens
+
+Section: Types
+  TokenKind =
+   | EndOfFile
+   | Identifier
+
+  Token = record {
+   kind : TokenKind,
+   source : Text,
+   offset : Integer,
+   length : Integer,
+   line : Integer,
+   column : Integer,
+   file-id : Integer
+  }
+
+Section: MergedLexer
+
+Section: Constants
+Section: Lexer State
+  mutable LexState = record {
+   source : Text,
+   offset : Integer,
+   line : Integer,
+   column : Integer,
+   file-id : Integer,
+   errors : LinkedList Integer,
+   prose-mode : Boolean
+  }
+
+  make-lex-state : Text, Integer, LinkedList Integer -> LexState
+  make-lex-state (src) (fid) (pre-errors) =
+   LexState {
+    source = src,
+    offset = 0,
+    line = 1,
+    column = 1,
+    file-id = fid,
+    errors = pre-errors,
+    prose-mode = False
+   }
+
+  advance-char : LexState -> LexState
+  advance-char (st) =
+   LexState {
+     source = st.source,
+     offset = st.offset + 1,
+     line = st.line,
+     column = st.column + 1,
+     file-id = st.file-id,
+     errors = st.errors,
+     prose-mode = st.prose-mode
+    }
+
+  LexStep =
+   | LexToken (Token) (LexState)
+   | LexEnd
+
+  make-token : TokenKind, Integer, LexState -> Token
+  make-token (kind) (length) (st) =
+   (Token {
+    kind = kind,
+    source = st.source,
+    offset = st.offset,
+    length = length,
+    line = st.line,
+    column = st.column,
+    file-id = st.file-id
+   })
+
+
+Section: Tokenize All
+  LexCollected = record {
+   collected-tokens : LinkedList Token,
+   collected-errors : LinkedList Integer
+  }
+
+Section: MergedLexStubs
+
+ Outside the kernel there are no phase decks; the identity stub mirrors
+ the one PlugTypes.codex carries for the same reason.
+
+Section: Stubs
+  deck-record : a -> a
+  deck-record (x) = x
+
+Section: MergedTokProbe
+
+  my-scan : LexState -> LexStep
+  my-scan (st) =
+   if st.offset >= 1 then LexEnd
+   else LexToken (make-token (deck-record Identifier) 1 st) (advance-char st)
+
+  my-collect : LexState, LinkedList Token, Integer -> LexCollected
+  my-collect (st) (acc) (ceiling) =
+   when my-scan st
+    is LexToken (tok) (next) ->
+     if tok.kind == EndOfFile then LexCollected { collected-tokens = __linked-list-push acc tok, collected-errors = next.errors }
+      else my-collect next (__linked-list-push acc tok) ceiling
+    is LexEnd ->
+     LexCollected { collected-tokens = __linked-list-push acc (make-token (deck-record EndOfFile) 0 st), collected-errors = st.errors }
+
+  opening : [Console] Nothing = act
+    let raw = my-collect (make-lex-state "x" 1 (__linked-list-empty 0)) (__linked-list-empty 0) 0
+    in act
+      print-line-uni ("toks " & show (list-length (__linked-list-to-list (raw.collected-tokens))))
+      print-line-uni ("errs " & show (list-length (__linked-list-to-list (raw.collected-errors))))
+    end
+  end

--- a/deck-record-repro/probe-site-record.codex
+++ b/deck-record-repro/probe-site-record.codex
@@ -1,0 +1,110 @@
+Chapter: Tokens
+
+Section: Types
+  TokenKind =
+   | EndOfFile
+   | Identifier
+
+  Token = record {
+   kind : TokenKind,
+   source : Text,
+   offset : Integer,
+   length : Integer,
+   line : Integer,
+   column : Integer,
+   file-id : Integer
+  }
+
+Section: MergedLexer
+
+Section: Constants
+Section: Lexer State
+  mutable LexState = record {
+   source : Text,
+   offset : Integer,
+   line : Integer,
+   column : Integer,
+   file-id : Integer,
+   errors : LinkedList Integer,
+   prose-mode : Boolean
+  }
+
+  make-lex-state : Text, Integer, LinkedList Integer -> LexState
+  make-lex-state (src) (fid) (pre-errors) =
+   LexState {
+    source = src,
+    offset = 0,
+    line = 1,
+    column = 1,
+    file-id = fid,
+    errors = pre-errors,
+    prose-mode = False
+   }
+
+  advance-char : LexState -> LexState
+  advance-char (st) =
+   LexState {
+     source = st.source,
+     offset = st.offset + 1,
+     line = st.line,
+     column = st.column + 1,
+     file-id = st.file-id,
+     errors = st.errors,
+     prose-mode = st.prose-mode
+    }
+
+  LexStep =
+   | LexToken (Token) (LexState)
+   | LexEnd
+
+  make-token : TokenKind, Integer, LexState -> Token
+  make-token (kind) (length) (st) =
+   deck-record (Token {
+    kind = kind,
+    source = st.source,
+    offset = st.offset,
+    length = length,
+    line = st.line,
+    column = st.column,
+    file-id = st.file-id
+   })
+
+
+Section: Tokenize All
+  LexCollected = record {
+   collected-tokens : LinkedList Token,
+   collected-errors : LinkedList Integer
+  }
+
+Section: MergedLexStubs
+
+ Outside the kernel there are no phase decks; the identity stub mirrors
+ the one PlugTypes.codex carries for the same reason.
+
+Section: Stubs
+  deck-record : a -> a
+  deck-record (x) = x
+
+Section: MergedTokProbe
+
+  my-scan : LexState -> LexStep
+  my-scan (st) =
+   if st.offset >= 1 then LexEnd
+   else LexToken (make-token Identifier 1 st) (advance-char st)
+
+  my-collect : LexState, LinkedList Token, Integer -> LexCollected
+  my-collect (st) (acc) (ceiling) =
+   when my-scan st
+    is LexToken (tok) (next) ->
+     if tok.kind == EndOfFile then LexCollected { collected-tokens = __linked-list-push acc tok, collected-errors = next.errors }
+      else my-collect next (__linked-list-push acc tok) ceiling
+    is LexEnd ->
+     LexCollected { collected-tokens = __linked-list-push acc (make-token EndOfFile 0 st), collected-errors = st.errors }
+
+  opening : [Console] Nothing = act
+    let raw = my-collect (make-lex-state "x" 1 (__linked-list-empty 0)) (__linked-list-empty 0) 0
+    in act
+      print-line-uni ("toks " & show (list-length (__linked-list-to-list (raw.collected-tokens))))
+      print-line-uni ("errs " & show (list-length (__linked-list-to-list (raw.collected-errors))))
+    end
+  end

--- a/deck-record-repro/repro-crash.codex
+++ b/deck-record-repro/repro-crash.codex
@@ -1,0 +1,110 @@
+Chapter: Tokens
+
+Section: Types
+  TokenKind =
+   | EndOfFile
+   | Identifier
+
+  Token = record {
+   kind : TokenKind,
+   source : Text,
+   offset : Integer,
+   length : Integer,
+   line : Integer,
+   column : Integer,
+   file-id : Integer
+  }
+
+Section: MergedLexer
+
+Section: Constants
+Section: Lexer State
+  mutable LexState = record {
+   source : Text,
+   offset : Integer,
+   line : Integer,
+   column : Integer,
+   file-id : Integer,
+   errors : LinkedList Integer,
+   prose-mode : Boolean
+  }
+
+  make-lex-state : Text, Integer, LinkedList Integer -> LexState
+  make-lex-state (src) (fid) (pre-errors) =
+   LexState {
+    source = src,
+    offset = 0,
+    line = 1,
+    column = 1,
+    file-id = fid,
+    errors = pre-errors,
+    prose-mode = False
+   }
+
+  advance-char : LexState -> LexState
+  advance-char (st) =
+   LexState {
+     source = st.source,
+     offset = st.offset + 1,
+     line = st.line,
+     column = st.column + 1,
+     file-id = st.file-id,
+     errors = st.errors,
+     prose-mode = st.prose-mode
+    }
+
+  LexStep =
+   | LexToken (Token) (LexState)
+   | LexEnd
+
+  make-token : TokenKind, Integer, LexState -> Token
+  make-token (kind) (length) (st) =
+   deck-record (Token {
+    kind = kind,
+    source = st.source,
+    offset = st.offset,
+    length = length,
+    line = st.line,
+    column = st.column,
+    file-id = st.file-id
+   })
+
+
+Section: Tokenize All
+  LexCollected = record {
+   collected-tokens : LinkedList Token,
+   collected-errors : LinkedList Integer
+  }
+
+Section: MergedLexStubs
+
+ Outside the kernel there are no phase decks; the identity stub mirrors
+ the one PlugTypes.codex carries for the same reason.
+
+Section: Stubs
+  deck-record : a -> a
+  deck-record (x) = x
+
+Section: MergedTokProbe
+
+  my-scan : LexState -> LexStep
+  my-scan (st) =
+   if st.offset >= 1 then LexEnd
+   else LexToken (make-token (deck-record Identifier) 1 st) (advance-char st)
+
+  my-collect : LexState, LinkedList Token, Integer -> LexCollected
+  my-collect (st) (acc) (ceiling) =
+   when my-scan st
+    is LexToken (tok) (next) ->
+     if tok.kind == EndOfFile then LexCollected { collected-tokens = __linked-list-push acc tok, collected-errors = next.errors }
+      else my-collect next (__linked-list-push acc tok) ceiling
+    is LexEnd ->
+     LexCollected { collected-tokens = __linked-list-push acc (make-token (deck-record EndOfFile) 0 st), collected-errors = st.errors }
+
+  opening : [Console] Nothing = act
+    let raw = my-collect (make-lex-state "x" 1 (__linked-list-empty 0)) (__linked-list-empty 0) 0
+    in act
+      print-line-uni ("toks " & show (list-length (__linked-list-to-list (raw.collected-tokens))))
+      print-line-uni ("errs " & show (list-length (__linked-list-to-list (raw.collected-errors))))
+    end
+  end


### PR DESCRIPTION
Continues the zig plug work from PR #64, rebased onto Update 43. The
fourteen commits you absorbed are gone from here; what remains is the work
that came after, replayed onto the new seed and re-verified against it.

## What this is for

Making the zig plug reliable enough to stand in for the bare-metal front
end in a mode that emits text, and using the effort of getting there to
find defects in Codex. The port is the vehicle.

## Measurement

Eight rungs, each bundling real compiler chapters into a subject, compiled
two ways -- seed on bare metal as truth, and through the zig plug -- and
required to agree byte for byte:

    lex -> parse -> desugar -> scope -> check -> lower -> text -> pingpong

All eight pass on seed F3722EAC. `text` emits canonical codex source out
of the IR through the plug; `pingpong` compiles that emitted source again
and requires the second text to equal the first. The fixed point holds
through the plug.

Re-banking against your new seed produced one result worth reporting: every
truth file came back byte-identical to the pre-Update-42 bank, across two
updates that touched 200 files including `Types/Unifier.codex`,
`IR/Lowering.codex`, `Types/TypeCheckerInference.codex` and
`Core/PhaseAllocator.codex`, all of which are inside these subjects. The IR
and the emitted zig moved. The observable behaviour did not.

## Findings

`deck-record-repro/README.md` now marks 1 through 5 CLOSED with what
landed, and keeps them only as a record. Three are open: `lift-lambdas`
sitting behind the plug wire, the absence of any `IRExpr` map or fold, and
`passes=text-plug` changing the type vocabulary without saying so.

Finding 4 is worth a second look. It closed as `check-subset-cites.ps1`
rather than as the one-line cite it asked for, which is a gate for the
whole class instead of an answer to the instance. Two of our own
accommodations broke when it and finding 5 landed -- a bundle that named
`Capability` outright, and an emitter check that dropped a duplicate
catch-all arm. Both are removed here. An accommodation is a record of a
defect held somewhere that cannot know when the defect goes away.

## The standing caveat

Update 43 records it fairly: the central claim here is our measurement, not
yours, because there is no zig toolchain on the build box. Nothing in this
PR changes that, and we would like to. Related and not included here: the
zig plug is absent from `build/plug-oracle-test.ps1` entirely, so its
status there is "not listed" rather than "unverified". Running that
subject through the zig plug by hand finds three real defects in our plug
-- a missing `int-mod` emitter, a record literal emitted without the
parentheses zig needs before a field access, and bounded-field clamping
not emitted at all. We would rather fix those and then add the arm than
add an arm we know is red. Say the word if you would prefer it listed and
failing.

Also worth knowing: `plug-oracle-test.ps1` runs `tools\codex-vm.exe`
directly for the truth arm rather than going through `compile.ps1`, so it
cannot run on a non-Windows box even where `compile.ps1` can.
