### PR TITLE
zig plug: pin a literal-armed switch, and let __linked-list-empty consume its size hint

### DIFF
--- a/codex/plugs/zig/ZigEmitter.codex
+++ b/codex/plugs/zig/ZigEmitter.codex
@@ -810,7 +810,7 @@ Section: Builtin Emitter
     ZigBuiltinEmitter { name = "__list-with-capacity", emit = \args ctx d ty -> "cx_ll_with_capacity(" & zig-ll-elem ty & ", " & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "text-compare", emit = \args ctx d ty -> "cx_text_compare(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ", " & emit-zig-expr (list-at args 1) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "char-to-text", emit = \args ctx d ty -> "cx_char_to_text(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
-    ZigBuiltinEmitter { name = "__linked-list-empty", emit = \args ctx d ty -> "cx_ll_empty(" & zig-ll-elem ty & ")" },
+    ZigBuiltinEmitter { name = "__linked-list-empty", emit = \args ctx d ty -> "cx_ll_with_capacity(" & zig-ll-elem ty & ", " & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "__linked-list-push", emit = \args ctx d ty -> "cx_ll_push(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ", " & emit-zig-expr (list-at args 1) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "__linked-list-to-list", emit = \args ctx d ty -> emit-zig-expr (list-at args 0) ctx (d + 1) },
     ZigBuiltinEmitter { name = "__deck-pos", emit = \args ctx d ty -> "0" },
@@ -1747,7 +1747,7 @@ Section: Match Emission
       else zig-arms-list-type branches 0 mty0
    in let ex = zig-match-exhaustive ctx (zig-expr-type scrut) branches
    in if zig-branches-guarded branches 0 then emit-zig-match-chain scrut branches ctx d mty
-   else "switch (" & emit-zig-expr scrut ctx (d + 1) & zig-match-deref ctx (zig-expr-type scrut) & ") { " & emit-zig-match-arms branches 0 ctx d ex mty & " }"
+   else zig-pin-lit-arms branches 0 ("switch (" & emit-zig-expr scrut ctx (d + 1) & zig-match-deref ctx (zig-expr-type scrut) & ") { " & emit-zig-match-arms branches 0 ctx d ex mty & " }")
 
   emit-zig-match-arms : List IRBranch, Integer, ZigCtx, Integer, Boolean, CodexType -> Text
   emit-zig-match-arms (branches) (i) (ctx) (d) (ex) (mty) =


### PR DESCRIPTION
Two small gaps, both siblings of code already in ZigEmitter.codex, found by
compiling the plug through itself and still present at a061c173.

**A plain switch with literal arms is unpinned.** An unguarded match whose
arms are bare integer or real literals emits a switch typed `comptime_int`,
which zig refuses to carry into a runtime context. `zig-pin-lit-arms`
already answers exactly this on the guarded chain; this PR applies the same
pin on the plain switch path, one call. In the original formulation of this
fix (measured on the Update 46 seed) the pin fired on about 1% of switches
(7 of 629 in the compiler's check phase, 8 of 805 in text) with zero output
change on every program measured; this PR re-expresses that fix through
your own `zig-pin-lit-arms`.

**`__linked-list-empty` drops its argument.** Any caller whose size-hint
binding has no second consumer then fails zig's unused-local check -- the
`__deck-set` shape again (a binding whose only consumer disappeared). The
`__list-with-capacity` row three lines up already answers this with
`cx_ll_with_capacity`, which consumes and discards the hint and returns an
empty list, so the row reuses it rather than adding a prelude twin.

Verified here: the plug compiles through the a061c173 seed with both
changes, and the hello/recurse/fib warmup oracles are byte-identical to
their bare-metal truths through the rebuilt plug. Our 14-rung ladder is
green on Update 47 with the same two fixes in their original formulation.
