### PR TITLE
zig plug: integer wrap, shadowed-builtin yield, and Char as a CCE code

### DIFF
--- a/codex/plugs/zig/ZigEmitter.codex
+++ b/codex/plugs/zig/ZigEmitter.codex
@@ -855,11 +855,19 @@ Section: Builtin Emitter
 
   lookup-zig-builtin : Text, List IRExpr, ZigCtx, Integer, CodexType -> Text
   lookup-zig-builtin (name) (args) (ctx) (d) (ty) =
-   let len = list-length zig-builtin-emitters
+   if lookup-arity (ctx.arities) name >= 0 & (zig-skip-def name == False) then ""
+   else let len = list-length zig-builtin-emitters
    in let pos = bsearch-zig-builtin-pos zig-builtin-emitters name 0 len
    in if pos >= len then ""
       else let e = list-at zig-builtin-emitters pos
       in if e.name == name then e.emit args ctx d ty else ""
+
+ A name the module itself defines is the module's: the user definition
+ wins over any builtin of the same name, so interception yields before
+ the table is consulted. The arity map is built from the unit's IRDefs,
+ which makes it the module-defined test. The one exemption is paired
+ with zig-skip-def: a definition deliberately not emitted has only its
+ intercept to answer for it, so the intercept must not yield.
 
 Section: Name Mapping
 
@@ -2424,7 +2432,10 @@ Section: Definition Emission
 
  subj-deck-record is the bundler's rename of the compiler's deck-record
  region hint; calls pass through as the argument and the identity def
- itself is skipped rather than emitted as an unusable generic.
+ itself is skipped rather than emitted as an unusable generic. Skipping
+ the def obliges the intercept: lookup-zig-builtin's yield-to-module-
+ definitions rule exempts exactly the names listed here, or every call
+ site would name a definition that was never emitted.
 
   zig-skip-def : Text -> Boolean
   zig-skip-def (n) = n == "subj-deck-record"

--- a/codex/plugs/zig/ZigEmitter.codex
+++ b/codex/plugs/zig/ZigEmitter.codex
@@ -774,12 +774,15 @@ Section: Builtin Emitter
  index. A target's own encoding appears at I/O and nowhere else, which for
  this plug means cx_cce_to_utf8 on the way to the terminal.
 
- A Char, though, is a CODEPOINT here, which is why char-code and
- code-to-char convert rather than vanish the way they do in the C# plug.
- That makes char-at the odd one out: it read the CCE byte and handed it
- back untranslated, so `char-code (char-at s i)` fed a CCE code to a table
- that wanted a codepoint and panicked. char-code-at is the one that answers
- in CCE, and it stays a bare read.
+ A Char is a CCE CODE here, the identity model bare metal and the C# plug
+ share: char-code and code-to-char vanish, char-at and char-code-at are the
+ same bare read, and a char literal's raw IR payload -- already a CCE code
+ -- compares equal to what char-at reads. Classification is banded in CCE
+ (cx_is_letter, cx_is_digit). The codepoint alternative was tried and is
+ structurally lossy: CCE has aliases (a tier-1 code and a tier-0 code can
+ name the same codepoint, and the canonical encoder picks tier 0), so any
+ code -> codepoint -> code detour canonicalises and corrupts byte-wise
+ text rebuilds. Codepoints exist at the I/O boundary only.
 
   zig-builtin-emitters : List ZigBuiltinEmitter =
    sort-zig-builtins [
@@ -805,8 +808,8 @@ Section: Builtin Emitter
     ZigBuiltinEmitter { name = "text-length", emit = \args ctx d ty -> "cx_text_len(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "char-code-at", emit = \args ctx d ty -> "cx_char_at(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ", " & emit-zig-expr (list-at args 1) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "substring", emit = \args ctx d ty -> "cx_substring(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ", " & emit-zig-expr (list-at args 1) ctx (d + 1) & ", " & emit-zig-expr (list-at args 2) ctx (d + 1) & ")" },
-    ZigBuiltinEmitter { name = "code-to-char", emit = \args ctx d ty -> "cx_cce_to_cp(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
-    ZigBuiltinEmitter { name = "char-code", emit = \args ctx d ty -> "cx_cp_to_cce(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
+    ZigBuiltinEmitter { name = "code-to-char", emit = \args ctx d ty -> "(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
+    ZigBuiltinEmitter { name = "char-code", emit = \args ctx d ty -> "(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "is-letter", emit = \args ctx d ty -> "cx_is_letter(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "is-digit", emit = \args ctx d ty -> "cx_is_digit(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "bit-and", emit = \args ctx d ty -> "(" & emit-zig-expr (list-at args 0) ctx (d + 1) & " & " & emit-zig-expr (list-at args 1) ctx (d + 1) & ")" },
@@ -830,7 +833,7 @@ Section: Builtin Emitter
     ZigBuiltinEmitter { name = "__deck-pos", emit = \args ctx d ty -> "cx_deck_pos()" },
     ZigBuiltinEmitter { name = "__deck-set", emit = \args ctx d ty -> "cx_deck_set(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "subj-deck-record", emit = \args ctx d ty -> emit-zig-expr (list-at args 0) ctx (d + 1) },
-    ZigBuiltinEmitter { name = "char-at", emit = \args ctx d ty -> "cx_cce_to_cp(cx_char_at(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ", " & emit-zig-expr (list-at args 1) ctx (d + 1) & "))" },
+    ZigBuiltinEmitter { name = "char-at", emit = \args ctx d ty -> "cx_char_at(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ", " & emit-zig-expr (list-at args 1) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "negate", emit = \args ctx d ty -> "(-" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "__narrow", emit = \args ctx d ty -> emit-zig-expr (list-at args 0) ctx (d + 1) },
     ZigBuiltinEmitter { name = "abs", emit = \args ctx d ty -> "@as(i64, @intCast(@abs(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")))" },
@@ -2746,8 +2749,8 @@ Section: Chapter Emission
    & "fn cx_text_to_double_bits(s: []const u8) i64 {\n    if (s.len == 0) return 0;\n    var i: usize = 0;\n    var neg = false;\n    if (s[0] == 73) {\n        neg = true;\n        i = 1;\n    }\n    var acc: i64 = 0;\n    var frac: i64 = 0;\n    var dot: i64 = 0;\n    while (i < s.len) : (i += 1) {\n        const b = s[i];\n        if (b == 65) {\n            dot = 1;\n            continue;\n        }\n        acc = acc *% 10 +% (@as(i64, b) -% 3);\n        frac += dot;\n    }\n    if (neg) acc = -%acc;\n    var v: f64 = @floatFromInt(acc);\n    if (frac != 0) {\n        var p: f64 = 1.0;\n        var k = frac;\n        while (k != 0) : (k -= 1) p *= 10.0;\n        v /= p;\n    }\n    return @bitCast(v);\n}\n"
    & "// real-f32 on bare metal is f32 bits in a general register (a movd\n// round-trip, emit-bits-to-real-approx-builtin); Real is f64 here, and\n// widening the named f32 value is exact.\n"
    & "fn cx_bits_to_real_approx(bits: i64) f64 {\n    return @floatCast(@as(f32, @bitCast(@as(u32, @truncate(@as(u64, @bitCast(bits)))))));\n}\n"
-   & "// A char is a CODEPOINT here and text is CCE, so making text from a\n// char must encode -- but encode to ONE byte, the way bare metal does:\n// emit-char-to-text-builtin stores the code with mov-store-byte, length 1,\n// no framing, truncating silently past 255. Byte-wise text rebuilds\n// (ir-quote walks char-code-at / code-to-char / char-to-text over every\n// byte) rely on that identity to pass CCE frame bytes through untouched;\n// framing here double-encodes the wire. The residue is the alias problem:\n// a 3-byte frame opener whose value collides with a tier-0 codepoint\n// (224, 225, 226, 228, 231-235, 237) canonicalises to the tier-0 code and\n// corrupts -- a limit of the codepoint-Char model itself, recorded in\n// PRIORITIES, not fixable in this function.\n"
-   & "fn cx_char_to_text(c: i64) []const u8 {\n    const b = cx_gpa.alloc(u8, 1) catch @panic(\"oom\");\n    b[0] = @truncate(@as(u64, @bitCast(cx_cp_to_cce(c))));\n    return b;\n}\n"
+   & "// A char is a CCE code and text is CCE, so making text from a char is\n// ONE raw byte, the way bare metal does: emit-char-to-text-builtin stores\n// the code with mov-store-byte, length 1, no framing, truncating silently\n// past 255. Byte-wise text rebuilds (ir-quote walks char-code-at /\n// code-to-char / char-to-text over every byte) rely on that identity to\n// pass CCE frame bytes through untouched; framing or converting here\n// corrupts the wire.\n"
+   & "fn cx_char_to_text(c: i64) []const u8 {\n    const b = cx_gpa.alloc(u8, 1) catch @panic(\"oom\");\n    b[0] = @truncate(@as(u64, @bitCast(c)));\n    return b;\n}\n"
    & "fn cx_list_len(l: anytype) i64 {\n    return @intCast(l.items.items.len);\n}\n"
    & "fn cx_list_at(l: anytype, i: i64) @TypeOf(l.items.items[0]) {\n    return l.items.items[@intCast(i)];\n}\n"
    & "fn cx_text_len(s: []const u8) i64 {\n    return @intCast(s.len);\n}\n"
@@ -2787,8 +2790,9 @@ Section: Chapter Emission
    & "// int-mod is Euclidean, so the result lands in [0, |b|) regardless of\n// either sign, where @rem takes the dividend's sign.\n"
    & "fn cx_mod(a: i64, b: i64) i64 {\n    const m = if (b < 0) -b else b;\n    const r = @rem(a, m);\n    return if (r < 0) r + m else r;\n}\n"
    & "fn cx_text_eq(a: []const u8, b: []const u8) bool {\n    return std.mem.eql(u8, a, b);\n}\n"
-   & "fn cx_is_letter(c: i64) bool {\n    return (c >= 'a' and c <= 'z') or (c >= 'A' and c <= 'Z');\n}\n"
-   & "fn cx_is_digit(c: i64) bool {\n    return c >= '0' and c <= '9';\n}\n"
+   & "// Classification is banded in CCE: 13..64 are the ASCII letters, 65..96\n// the punctuation between, 97..127 the accented Latin and Cyrillic\n// letters, 3..12 the digits -- the same two-band test bare metal's\n// emit-is-letter-builtin encodes.\n"
+   & "fn cx_is_letter(c: i64) bool {\n    return (c >= 13 and c <= 64) or (c >= 97 and c <= 127);\n}\n"
+   & "fn cx_is_digit(c: i64) bool {\n    return c >= 3 and c <= 12;\n}\n"
    & "fn cx_new(v: anytype) *@TypeOf(v) {\n    const p = cx_gpa.create(@TypeOf(v)) catch @panic(\"oom\");\n    p.* = v;\n    return p;\n}\n"
    & "fn cx_concat(a: []const u8, b: []const u8) []const u8 {\n    return std.mem.concat(cx_gpa, u8, &.{ a, b }) catch @panic(\"oom\");\n}\n"
    & "fn cx_text_starts_with(s: []const u8, p: []const u8) bool {\n    return std.mem.startsWith(u8, s, p);\n}\n"

--- a/codex/plugs/zig/ZigEmitter.codex
+++ b/codex/plugs/zig/ZigEmitter.codex
@@ -460,6 +460,19 @@ Section: Type Mapping
     is EffectfulTy (effs) (scopes) (inner) -> zig-is-text-type inner
     is otherwise -> False
 
+ Integer arithmetic wraps: Integer is the 64-bit machine word, bare metal
+ emits plain add/sub/mul/neg, and C#'s unchecked context does the same.
+ Zig's +/-/* are overflow-checked, so the integer rows carry the wrapping
+ forms and negation asks this predicate which family it is in.
+
+  zig-is-real-type : CodexType -> Boolean
+  zig-is-real-type (ty) =
+   when ty
+    is RealTy (w) (m) -> True
+    is VectorTy (vn) (vt) -> zig-is-real-type vt
+    is EffectfulTy (effs) (scopes) (inner) -> zig-is-real-type inner
+    is otherwise -> False
+
 Section: Arity Map
 
   ArityEntry = record {
@@ -1001,9 +1014,12 @@ Section: Binary Operator Mapping
   zig-bin-op-symbol : IRBinaryOp -> Text
   zig-bin-op-symbol (op) =
    when op
-    is IrAddInt | IrAddNum | IrAddVec | IrAddRealApprox | IrAddRealTrapping | IrAddRealSaturating -> "+"
-    is IrSubInt | IrSubNum | IrSubVec | IrSubRealApprox | IrSubRealTrapping | IrSubRealSaturating -> "-"
-    is IrMulInt | IrMulNum | IrMulVec | IrMulRealApprox | IrMulRealTrapping | IrMulRealSaturating -> "*"
+    is IrAddInt -> "+%"
+    is IrSubInt -> "-%"
+    is IrMulInt -> "*%"
+    is IrAddNum | IrAddVec | IrAddRealApprox | IrAddRealTrapping | IrAddRealSaturating -> "+"
+    is IrSubNum | IrSubVec | IrSubRealApprox | IrSubRealTrapping | IrSubRealSaturating -> "-"
+    is IrMulNum | IrMulVec | IrMulRealApprox | IrMulRealTrapping | IrMulRealSaturating -> "*"
     is IrDivInt | IrDivNum | IrDivVec | IrDivRealApprox | IrDivRealTrapping | IrDivRealSaturating -> "/"
     is IrRemInt -> "%"
     is IrPowInt -> "**"
@@ -1031,7 +1047,7 @@ Section: Binary Operator Mapping
     is IrConsList -> "cx_ll_cons(" & emit-zig-expr l ctx (d + 1) & ", " & emit-zig-expr r ctx (d + 1) & ")"
     is IrDivInt -> "@divTrunc(" & emit-zig-expr l ctx (d + 1) & ", " & emit-zig-expr r ctx (d + 1) & ")"
     is IrRemInt -> "@rem(" & emit-zig-expr l ctx (d + 1) & ", " & emit-zig-expr r ctx (d + 1) & ")"
-    is IrPowInt -> "std.math.pow(i64, " & emit-zig-expr l ctx (d + 1) & ", " & emit-zig-expr r ctx (d + 1) & ")"
+    is IrPowInt -> "cx_ipow(" & emit-zig-expr l ctx (d + 1) & ", " & emit-zig-expr r ctx (d + 1) & ")"
     is IrAnd -> "(" & emit-zig-expr l ctx (d + 1) & " and " & emit-zig-expr r ctx (d + 1) & ")"
     is IrOr -> "(" & emit-zig-expr l ctx (d + 1) & " or " & emit-zig-expr r ctx (d + 1) & ")"
     is IrEq ->
@@ -1294,7 +1310,9 @@ Section: Expression Emission
     is IrCharLit (n) (sp) -> integer-to-text n
     is IrName (n) (ty) (sp) -> emit-zig-name n ty ctx d
     is IrBinary (op) (l) (r) (ty) (sp) -> emit-zig-binary op l r ctx d
-    is IrNegate (operand) (nty) (sp) -> "(-" & emit-zig-expr operand ctx (d + 1) & ")"
+    is IrNegate (operand) (nty) (sp) ->
+     if zig-is-real-type nty then "(-" & emit-zig-expr operand ctx (d + 1) & ")"
+     else "(-%" & emit-zig-expr operand ctx (d + 1) & ")"
     is IrIf (c) (t) (el) (ty) (sp) -> zig-pin-lit t el ("(if (" & emit-zig-expr c ctx (d + 1) & ") " & emit-zig-if-branch t ty el (zig-expect ctx ty) d & " else " & emit-zig-if-branch el ty t (zig-expect ctx ty) d & ")")
     is IrLet (name) (ty) (val) (body) (sp) ->
      if zig-is-seq-name name then zig-label d & ": { _ = " & emit-zig-expr val ctx (d + 1) & "; break :" & zig-label d & " " & emit-zig-expr body ctx (d + 1) & "; }"
@@ -2724,8 +2742,9 @@ Section: Chapter Emission
    & "fn cx_text_len(s: []const u8) i64 {\n    return @intCast(s.len);\n}\n"
    & "fn cx_char_at(s: []const u8, i: i64) i64 {\n    return @intCast(s[@intCast(i)]);\n}\n"
    & "fn cx_substring(s: []const u8, start: i64, len: i64) []const u8 {\n    const a: usize = @min(@as(usize, @intCast(@max(start, 0))), s.len);\n    const b: usize = @min(a + @as(usize, @intCast(@max(len, 0))), s.len);\n    return s[a..b];\n}\n"
-   & "fn cx_shl(a: i64, b: i64) i64 {\n    return a << @as(u6, @intCast(b));\n}\n"
-   & "fn cx_shr(a: i64, b: i64) i64 {\n    return a >> @as(u6, @intCast(b));\n}\n"
+   & "fn cx_ipow(a: i64, b: i64) i64 {\n    if (b < 0) return 0;\n    var acc: i64 = 1;\n    var base = a;\n    var e = b;\n    while (e > 0) {\n        if ((e & 1) == 1) acc = acc *% base;\n        base = base *% base;\n        e = e >> 1;\n    }\n    return acc;\n}\n"
+   & "fn cx_shl(a: i64, b: i64) i64 {\n    return a << @as(u6, @intCast(b & 63));\n}\n"
+   & "fn cx_shr(a: i64, b: i64) i64 {\n    return a >> @as(u6, @intCast(b & 63));\n}\n"
    & "// The buffer model is the C# plug's: one flat zero-filled arena, a bump\n// pointer, and buffers as offsets into it. Reads and writes grow it on\n// demand, which matches an arena the guest zero-fills at boot. The bump\n// pointer boots at bare metal's own heap base (boot does mov r10, 6291456):\n// the absolute value is observable -- the depot's arith-narrow-proven\n// asserts __heap-save > 0 as a structural fact -- so the hosted arm answers\n// with bare metal's number, not an offset from a private zero.\n"
    & "var cx_heap: std.ArrayListUnmanaged(u8) = .empty;\n"
    & "var cx_hp: i64 = 6291456;\n"
@@ -2753,7 +2772,7 @@ Section: Chapter Emission
    & "fn cx_buf_write_bytes(b: i64, off: i64, vs: anytype) i64 {\n    const n: i64 = @intCast(vs.items.items.len);\n    cx_buf_want(b + off + n);\n    for (vs.items.items, 0..) |v, i| cx_heap.items[@as(usize, @intCast(b + off)) + i] = @intCast(@mod(v, 256));\n    return off + n;\n}\n"
    & "fn cx_peek_byte(b: i64, off: i64) i64 {\n    cx_buf_want(b + off + 1);\n    return cx_heap.items[@intCast(b + off)];\n}\n"
    & "fn cx_buf_read_bytes(b: i64, off: i64, n: i64) *CxList(i64) {\n    cx_buf_want(b + off + n);\n    const l = cx_ll_empty(i64);\n    l.items.ensureTotalCapacity(cx_gpa, @intCast(n)) catch @panic(\"oom\");\n    var cx_j: i64 = 0;\n    while (cx_j < n) : (cx_j += 1) l.items.appendAssumeCapacity(cx_heap.items[@as(usize, @intCast(b + off + cx_j))]);\n    return l;\n}\n"
-   & "fn cx_shru(a: i64, b: i64) i64 {\n    return @bitCast(@as(u64, @bitCast(a)) >> @as(u6, @intCast(b)));\n}\n"
+   & "fn cx_shru(a: i64, b: i64) i64 {\n    return @bitCast(@as(u64, @bitCast(a)) >> @as(u6, @intCast(b & 63)));\n}\n"
    & "// int-mod is Euclidean, so the result lands in [0, |b|) regardless of\n// either sign, where @rem takes the dividend's sign.\n"
    & "fn cx_mod(a: i64, b: i64) i64 {\n    const m = if (b < 0) -b else b;\n    const r = @rem(a, m);\n    return if (r < 0) r + m else r;\n}\n"
    & "fn cx_text_eq(a: []const u8, b: []const u8) bool {\n    return std.mem.eql(u8, a, b);\n}\n"
@@ -2766,7 +2785,7 @@ Section: Chapter Emission
    & "fn cx_text_concat_list(l: anytype) []const u8 {\n    var out = std.ArrayListUnmanaged(u8).empty;\n    for (l.items.items) |p| out.appendSlice(cx_gpa, p) catch @panic(\"oom\");\n    return out.items;\n}\n"
    & "fn cx_list_set_at(l: anytype, i: i64, v: anytype) @TypeOf(l) {\n    l.items.items[@intCast(i)] = v;\n    return l;\n}\n"
    & "// Text is CCE here, so a decimal digit is byte 3 + d and minus is 73;\n// parsing this as ASCII would silently read zero.\n"
-   & "fn cx_text_to_integer(s: []const u8) i64 {\n    var acc: i64 = 0;\n    var neg = false;\n    for (s, 0..) |b, i| {\n        if (i == 0 and b == 73) { neg = true; continue; }\n        if (b < 3 or b > 12) break;\n        acc = acc * 10 + @as(i64, b - 3);\n    }\n    return if (neg) -acc else acc;\n}\n"
+   & "fn cx_text_to_integer(s: []const u8) i64 {\n    var acc: i64 = 0;\n    var neg = false;\n    for (s, 0..) |b, i| {\n        if (i == 0 and b == 73) { neg = true; continue; }\n        if (b < 3 or b > 12) break;\n        acc = acc *% 10 +% @as(i64, b - 3);\n    }\n    return if (neg) -%acc else acc;\n}\n"
    & "fn cx_text_replace(s: []const u8, a: []const u8, b: []const u8) []const u8 {\n    if (a.len == 0) return s;\n    var out = std.ArrayListUnmanaged(u8).empty;\n    var i: usize = 0;\n    while (i < s.len) {\n        if (i + a.len <= s.len and std.mem.eql(u8, s[i .. i + a.len], a)) {\n            out.appendSlice(cx_gpa, b) catch @panic(\"oom\");\n            i += a.len;\n        } else {\n            out.append(cx_gpa, s[i]) catch @panic(\"oom\");\n            i += 1;\n        }\n    }\n    return out.items;\n}\n"
    & "fn cx_text_split(s: []const u8, sep: []const u8) *CxList([]const u8) {\n    const out = cx_ll_empty([]const u8);\n    if (sep.len == 0) {\n        _ = cx_ll_push(out, s);\n        return out;\n    }\n    var start: usize = 0;\n    while (std.mem.indexOfPos(u8, s, start, sep)) |p| {\n        _ = cx_ll_push(out, s[start..p]);\n        start = p + sep.len;\n    }\n    _ = cx_ll_push(out, s[start..]);\n    return out;\n}\n"
    & "const cce_table = [128]u32{ 0, 10, 32, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 101, 116, 97, 111, 105, 110, 115, 104, 114, 100, 108, 99, 117, 109, 119, 102, 103, 121, 112, 98, 118, 107, 106, 120, 113, 122, 69, 84, 65, 79, 73, 78, 83, 72, 82, 68, 76, 67, 85, 77, 87, 70, 71, 89, 80, 66, 86, 75, 74, 88, 81, 90, 46, 44, 33, 63, 58, 59, 39, 34, 45, 40, 41, 43, 61, 42, 60, 62, 47, 64, 35, 38, 95, 92, 124, 91, 93, 123, 125, 126, 96, 94, 36, 37, 233, 232, 234, 235, 225, 224, 226, 228, 243, 244, 246, 250, 252, 241, 231, 237, 1072, 1086, 1077, 1080, 1085, 1090, 1089, 1088, 1074, 1083, 1082, 1084, 1076, 1087, 1091 };\n"


### PR DESCRIPTION
Three commits for the zig plug, found by running your test corpus through it and diffing against the `.expected` oracles. All three are fixes on our side; the corpus evidence and the convergence story are below.

**1. Integer arithmetic wraps (`zig plug: integer arithmetic wraps -- Integer is the machine word`)**

Zig's `+`/`-`/`*` are overflow-checked, so the plug panicked where bare metal wraps. The ruling that wrap is the language's rule rests on five converging sources: CodexSubtypes says Integer IS the 64-bit machine word; the IR names behavior wherever it deviates (`IrAddRealTrapping`/`Saturating`) and `IrAddInt` is the plain op; the C# plug emits bare `+` in C#'s default unchecked context; bare metal emits `add`/`imul`/`neg` with no `jo` anywhere; and Foreword's own BloomFilter iterates `hash * 31 + c` unbounded and then tests `if h < 0 then -h` — written against wrap. The commit: `+%`/`-%`/`*%` on the integer rows, `-%` for non-real negation, `cx_ipow` mirroring `__ipow` (negative exponent → 0, wrapping square-and-multiply) in place of `std.math.pow` (panics on both overflow and negative exponents), shift counts masked `& 63` (x86 `cl` semantics; C#'s `<<` on long masks identically).

Corpus effect: the three `panic: integer overflow` subjects (`bloom-spread`, `consistent-hash-balance`, `particle-spread`) now match their `.expected` — and 36 additional programs that previously died in the *hosted compiler itself* (codexir compiled through this plug aborting on checked arithmetic) now compile; 15 of them match outright.

**2. Builtin interception yields to names the module defines (`zig plug: builtin interception yields...`)**

`shadow-builtin-fold` shadows `text-length` and `abs`; the emitted zig contained the user's functions but call sites were hijacked by the builtin-emitter name table (got 3/3/5 where the oracle says 99/99/77). `lookup-zig-builtin` now yields when the unit's own IRDefs know the name, with one paired exemption: a name on the `zig-skip-def` list deliberately has no emitted definition, so its intercept must not yield.

**3. Char is a CCE code (`zig plug: Char is a CCE code, the identity model bare metal and C# share`)**

Follows through on the direction of the CCE-tiers work you absorbed in Update 48: the plug's Char was a Unicode codepoint while `IrCharLit` carried the raw CCE payload, so `char-at s i == 'x'` compared across two alphabets and was false for every letter (`text-fold-indexed`: vowel count 0). The codepoint model is also structurally lossy — CCE aliases canonicalise through any code→codepoint→code detour. This migrates to the identity model bare metal and the C# plug share: `char-code`/`code-to-char` vanish, `char-at` is the same bare read as `char-code-at`, `char-to-text` stores one raw byte, `is-letter`/`is-digit` use the CCE bands your `emit-is-letter-builtin` encodes (13..64 ∪ 97..127, digits 3..12). Codepoints now exist only at the I/O boundary.

Verified by convergence: two probes (`probe-char-literal`, `probe-char-ops`, in the ladder's findings directory) print line-identical output on bare metal and the migrated zig arm, including the accented/Cyrillic second letter band.

**Evidence for the set**: our 14-rung ladder sweep is green over the chain, and the full 566-program census re-bank moved 42 verdicts with zero regressions — the differ, crashed, and hosted-compiler-abort buckets are all empty now (182/566 match; the remainder are our own emitter gaps, not divergences).

**Two source-read asides, not demonstrated, offered in case they're useful**: the Python plug emits `+` on unbounded ints with no 64-bit mask, so it silently diverges from bare metal on any overflow (JS is worse — f64 past 2^53); and `CSharpEmitterExpressions` maps `IrPowInt` to `^`, which is XOR in C#, not exponentiation. `plug-oracle-arith` has no overflow row that would catch either; happy to propose one if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
