### PR TITLE
zig plug: the stack note's stated mechanism is gone, so the note says so

### DIFF
--- a/codex/plugs/zig/ZigEmitter.codex
+++ b/codex/plugs/zig/ZigEmitter.codex
@@ -3233,8 +3233,15 @@ Section: Chapter Emission
  and every one of its recursive calls is in tail position, so this plug
  emits it as a loop. The parser's top-level scans DID drive the depth --
  2,393 nested scan-top-level frames on the 2.5 MB back-end unit -- and
- they now return their item rather than mutually tail-calling, which
- leaves each one tail-calling ITSELF, so they are loops here too.
+ they now return their item rather than mutually tail-calling, so
+ parse-top-level is a loop here as well. Two of its arms still leave that
+ loop: an `effect` declaration goes out through parse-top-level-effect and
+ a top-level `claim` through parse-claim-arm and parse-simple-claim, and
+ each of those tail-calls parse-top-level back, which self-tail
+ elimination does not reach. They cost a frame apiece and they are rare:
+ eight effect declarations and no claims in that same 2.5 MB unit, three
+ and none in the parser. A residue of eight frames is not what a 512 MB
+ stack is for.
 
  That makes 512 MB a number whose stated mechanism is gone, and the answer
  to that is to measure before lowering it rather than to lower it. Only

--- a/codex/plugs/zig/ZigEmitter.codex
+++ b/codex/plugs/zig/ZigEmitter.codex
@@ -3212,20 +3212,35 @@ Section: Definition Emission
 Section: Chapter Emission
 
  Codex is written to recurse rather than loop, and bare metal answers that
- with a multi-gigabyte arena. Zig gives a main thread 8 MB, which is not
- enough: scan-class-instance-defs recurses once per token, so Parser.codex
- at 18,812 tokens overflows and segfaults. ReleaseFast does not rescue it,
- since the calls sit inside labelled block expressions.
+ with a multi-gigabyte arena. Zig gives a main thread 8 MB. That was not
+ enough when this plug emitted a call for every self-recursion:
+ scan-class-instance-defs recurses once per token, and Parser.codex at
+ 18,812 tokens overflowed and segfaulted. ReleaseFast does not rescue that
+ shape, since the calls sit inside labelled block expressions.
 
  This is the same wall CSharpPlug hit, and this is its answer -- run the
  entry point on a thread with a big stack, reserved address space
- committed on demand. Read the note above opening-on-big-stack there for
- the part that matters most: the case that reaches the limit is MUTUAL
- recursion, the lexer's scan-token -> skip-prose-line -> scan-token cycle,
- and no amount of self-tail-call elimination flattens that. Emitting loops
- for self-recursion would be a real feature and would still not remove the
- need for this. .NET gives its main thread 1 MB and overflows on a 96-byte
- chapter, so this is a property of the source rather than of large input.
+ committed on demand. .NET gives its main thread 1 MB and overflows on a
+ 96-byte chapter, so the need is a property of the source rather than of
+ large input.
+
+ No cycle this note can name is what holds the stack up any more, and the
+ three worth naming are settled, so the next reader does not re-derive
+ them. The lexer's scan-token -> skip-prose-line -> scan-token pair is
+ MUTUAL and no self-tail transformation reaches it -- but it is measured
+ FLAT: 100,000 consecutive prose lines run in a 256 KB stack, so it is not
+ the case to reason from. scan-class-instance-defs recurses once per token
+ and every one of its recursive calls is in tail position, so this plug
+ emits it as a loop. The parser's top-level scans DID drive the depth --
+ 2,393 nested scan-top-level frames on the 2.5 MB back-end unit -- and
+ they now return their item rather than mutually tail-calling, which
+ leaves each one tail-calling ITSELF, so they are loops here too.
+
+ That makes 512 MB a number whose stated mechanism is gone, and the answer
+ to that is to measure before lowering it rather than to lower it. Only
+ codexir has been bisected against real documents; zigemit and the other
+ natives have their own recursion and are unmeasured, so what one input
+ needs is known and what every input needs is not.
 
  512 MB matches the C# default deliberately. What is NOT matched is its
  CODEX_STACK_MB override: zig 0.16's environment API is mid-refactor


### PR DESCRIPTION
Two commits, one file, `codex/plugs/zig/ZigEmitter.codex` (+33/-11), and every line of it is inside one prose block. **The 512 MB constant is untouched.**

- `09ce8ba8` the note names three cycles, and all three are flat now
- `87f55675` the top-level scan is a loop, and the two arms that are not are counted

## The defect

The note above `zig-main` justifies a 512 MB thread stack, and every mechanism it names to justify it is gone. It reads:

> the case that reaches the limit is MUTUAL recursion, the lexer's scan-token -> skip-prose-line -> scan-token cycle, and no amount of self-tail-call elimination flattens that. Emitting loops for self-recursion would be a real feature and would still not remove the need for this.

Both halves of that last sentence shipped in the same push the note now sits in. #81 emits loops for self-recursion, and #82 turned the parser's top-level scans from mutual into self recursion so that the transformation reaches them. A justification that argues against two changes standing beside it in the tree is worse than no justification, because the next reader trusts it.

## What the three named cycles actually do now

Each was read out of the swept `ast/parse.zig` under seed `6CF4A8E0`, not argued from the source:

- **The lexer's `scan-token` -> `skip-prose-line` -> `scan-token` pair** is still mutual, and no self-tail transformation reaches it. It is also measured **flat**: 100,000 consecutive prose lines run in a 256 KB stack. It is not the case to reason from.
- **`scan-class-instance-defs`** recurses once per token and every recursive call is in tail position, so the plug emits it as `while (true)`. Its name appears in the emitted file exactly twice: the definition and its one call site.
- **The parser's top-level scans** did drive the depth — 2,393 nested frames on the 2.5 MB back-end unit. After #82, `parse-top-level` emits as a loop too.

## The residue, counted rather than assumed

Two arms still leave that loop: an `effect` declaration returns through `parse-top-level-effect`, and a top-level `claim` through `parse-claim-arm` and `parse-simple-claim`. Each tail-calls `parse-top-level` back, and that cycle is mutual, so self-tail elimination does not reach it. It costs one frame per occurrence, and the occurrences were counted: **eight effect declarations and no claims in that same 2.5 MB unit, three and none in the parser.** A residue of eight frames is not what a 512 MB stack is for.

## What this PR does NOT do

It does not lower the constant. Only `codexir` has been bisected against real documents; `zigemit` and the other natives have their own recursion and are unmeasured, so what one input needs is known and what every input needs is not. The note now says to measure before lowering rather than to lower — and it keeps the .NET data point, which is the one argument in the original that survives: .NET gives its main thread 1 MB and overflows on a 96-byte chapter, so the need is a property of the source rather than of large input.

## Measured

A prose block is compiled source here, not a host-language comment, so "it is only prose" is an argument and not a measurement. Swept against the interim push (`0c4327d5`) in its own sandbox:

```
bundle        10072 lines, 484804 bytes  ->  10094 lines, 486098 bytes
fingerprint   1aba3c41196cb74e           ->  73dc2f1e8cd0ed81
sweep         14/14 rungs green, 1627 s
emitted zig   13 files, every one byte-identical
```

A different plug binary — 22 lines and 1294 bytes larger, different fingerprint — emitting the same program for all thirteen subjects.

Ladder: stack-prose-verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)
