### PR TITLE
zig plug: a self-tail loop reads a top-level definition where the source reads its own parameter

### DIFF
--- a/codex/plugs/plugs-backlog.md
+++ b/codex/plugs/plugs-backlog.md
@@ -248,6 +248,85 @@ definition is required of every plug that keeps an arity map -- in which
 case riscv wants its dead function wired up and java wants an arity
 check -- or whether some plugs are exempt, and `:258` should say which.
 
+**1.58 -- the zig plug's self-tail loop reads a TOP-LEVEL DEFINITION where
+the source reads its own parameter, and two blind spots had to line up for
+it to be silent. OURS, from PR 81, and already in the tree.** Found
+2026-08-25 when the ladder's census re-pin moved `dtls-fragment` from
+`match` to `refused`: `corpus/dtls-fragment.zig:942:57: error: unused
+function parameter`. The refusal is the symptom; the defect under it
+returns a wrong number with no diagnostic.
+
+**The mechanism.** `dtls-frag-loop`
+(`codex/foreword/encode/DtlsMessage.codex:97`) takes parameters `body` and
+`msg-type`, and the test bundled beside it defines top-level `body` and
+`msg-type` (`codex/test/dtls-fragment.codex:21,23`). Zig forbids a
+parameter shadowing a top-level declaration, so `zig-def-param-name`
+renames them to `_arg_body` and `_arg_msg_type` -- correctly. The emitted
+loop body then calls `body()` and `msg_type()`, which are the top-level
+definitions. `dtls_msg_encode` in the same file takes the same two renamed
+parameters and reads them correctly (`cx_list_len(_arg_body)`): the
+non-loop emission binds the rename and the self-tail-loop emission did
+not.
+
+`emit-zig-def`'s loop branch built its body context from
+`zig-push-tail-renames`, which covers the parameters the loop REASSIGNS
+and only those. An invariant slot is never assigned, gets no loop var, and
+so got no rename at all -- and a parameter of that kind whose name shadows
+a definition fell through to the definition. The fix composes
+`zig-push-param-renames` underneath it, so an invariant parameter resolves
+to its `_arg_` name while the tail renames still win for the reassigned
+ones (`zig-renamed-scan` reads from the end). The non-loop branch has
+always done this; the two branches now agree.
+
+**Why it was silent, which is the part worth reading.** The obvious
+minimization of this defect CANNOT produce a wrong answer. `zig-occurs`
+drives a discard: a parameter it believes unread is emitted as
+`_ = _arg_x;`, one it believes read is not. So a read the check can SEE
+means no discard, no surviving mention of `_arg_x` after the substitution,
+and zig refusing an unused parameter -- which is exactly what
+`dtls-fragment` did. Measured, not argued: a three-line version refuses
+with the same error.
+
+The silent form needs a read the check is blind to, and
+`zig-occurs-branches` walked a branch's body and not its GUARD. A match
+guard inside one of the loop's own tail-call arguments is therefore
+invisible to the check -- so the discard is emitted and the program builds
+-- and emitted by the loop path, reading the global. That is the second
+hunk. The guard also has to sit inside a tail-call argument rather than at
+the top of the body: a guarded match in tail position is not recognised as
+a self tail call at all, so that shape never becomes a loop and answers
+correctly.
+
+**A third hunk, from the file's own instruction.** `zig-max-list-len`
+carries the note "The walk mirrors zig-occurs: same nodes, same reason to
+visit them, and the same consequence for a node it forgets", and its
+`zig-max-list-len-branches` had the identical guard hole. Demonstrated
+before fixing: the same 40-element literal emits `@setEvalBranchQuota` in
+a branch body and none in a branch guard. That failure is loud (a zig
+comptime resource error) rather than silent, and no program in the corpus
+hits it today. Neither walk descends into an effect handler's clauses, and
+that one is deliberate -- `emit-zig-expr` answers `@compileError` for any
+`IrHandle` carrying clauses, so nothing beneath one is ever emitted.
+
+**Verification, in the order it was done.** A tier row FIRST and it had to
+fail: `prim-tailcall`'s `shadow-guard` row, bare metal 3 against the zig
+arm's 5, on a loop whose parameter `stop-at` is 3 and whose top-level
+`stop-at` is 100. Then the fix, then: the row green on both arms; the
+ladder's 22-tier set green (15 green, 7 noted, 0 unexpected); 14 of 14
+rungs green in a sweep; `dtls-fragment` back to `match` in the census;
+and every one of the ladder's own units emitting byte-identical zig
+across the two emitter builds, save the emitter's own bundle, which
+contains the fix.
+
+**Where the instrument was blind, since that is the reusable part.**
+`prim-tailcall` had exercised loop conversion since the day it was
+written and was green throughout: no row gave a loop a parameter that
+shadowed a top-level definition, so the whole class sat outside the tier
+set. What caught it was the depot's own corpus -- a program written by
+someone with no knowledge of this plug, containing the collision by
+accident.
+
+
 **babbage is SHELVED** (Damian, 2026-08-21): vanity work. Its open items
 moved to `codex/plugs/babbage/babbage-backlog.md`. Do not add babbage items
 here.

--- a/codex/plugs/zig/ZigEmitter.codex
+++ b/codex/plugs/zig/ZigEmitter.codex
@@ -1316,10 +1316,19 @@ Section: Expression Emission
    if i >= list-length es then False
    else zig-occurs (list-at es i) n | zig-occurs-list es (i + 1) n
 
+ A branch's GUARD is part of the branch. Reading only the body answered
+ "does not occur" for a name a guard mentions, and every caller of this
+ uses the answer to decide whether to discard something -- so a name
+ read only from a guard was discarded and then emitted, which zig calls
+ a pointless discard, or was left out of a lambda's captures. An
+ unguarded branch carries a True literal here, so this costs nothing on
+ the common shape.
+
   zig-occurs-branches : List IRBranch, Integer, Text -> Boolean
   zig-occurs-branches (bs) (i) (n) =
    if i >= list-length bs then False
-   else zig-occurs ((list-at bs i).body) n | zig-occurs-branches bs (i + 1) n
+   else zig-occurs ((list-at bs i).guard) n | zig-occurs ((list-at bs i).body) n
+      | zig-occurs-branches bs (i + 1) n
 
   zig-occurs-stmts : List IRActStmt, Integer, Text -> Boolean
   zig-occurs-stmts (ss) (i) (n) =
@@ -3067,6 +3076,17 @@ Section: Definition Emission
    else "comptime T" & integer-to-text (list-at ids i) & ": type, "
       & zig-comptime-params ids (i + 1)
 
+ The loop body's context takes BOTH renames, and the order is the whole
+ of it. zig-push-tail-renames covers the parameters the loop reassigns
+ and only those: an invariant slot is never assigned, so it gets no loop
+ var and no rename, and a parameter of that kind whose name shadows a
+ top-level definition then resolved to THE DEFINITION -- the loop read a
+ global where the source read its own argument, silently. Composing
+ zig-push-param-renames underneath restores the `_arg_` name for exactly
+ those parameters, and the tail renames still win for the reassigned
+ ones because zig-renamed-scan reads from the end. The non-loop branch
+ below has always done this; the two branches now agree.
+
   emit-zig-def : IRDef, ZigCtx -> Text
   emit-zig-def (d) (ctx0) =
    if zig-skip-def (d.name) then ""
@@ -3098,7 +3118,7 @@ Section: Definition Emission
    then head
     & emit-zig-tail-vars (d.params) 0 (d.body) (zig-push-param-renames ctx (d.params) 0) (tl.tail-vars) tl
     & "    while (true) {\n        "
-    & emit-zig-tail (d.body) (zig-push-bound-params (zig-push-tail-renames ctx (d.params) 0 (tl.tail-vars)) (d.params) 0) 0 tl
+    & emit-zig-tail (d.body) (zig-push-bound-params (zig-push-tail-renames (zig-push-param-renames ctx (d.params) 0) (d.params) 0 (tl.tail-vars)) (d.params) 0) 0 tl
     & "\n    }\n}\n\n"
    else head
     & emit-zig-param-discards (d.params) 0 (d.body)
@@ -3127,6 +3147,14 @@ Section: Definition Emission
  and the same consequence for a node it forgets -- here a quota that
  stays default under a literal that needed it, which fails loudly at
  zig compile time.
+
+ Both walks skipped a branch's GUARD, and both were fixed together for
+ that reason: a 40-element literal in a guard was measured emitting no
+ @setEvalBranchQuota while the identical literal one field over, in the
+ branch's body, emitted one. Neither walk descends into an effect
+ handler's clauses either, and that one is deliberate -- emit-zig-expr
+ answers @compileError for any IrHandle carrying clauses, so nothing
+ beneath one is ever emitted and there is nothing to count.
 
   zig-max2 : Integer, Integer -> Integer
   zig-max2 (a) (b) = if a >= b then a else b
@@ -3161,7 +3189,9 @@ Section: Definition Emission
   zig-max-list-len-branches : List IRBranch, Integer -> Integer
   zig-max-list-len-branches (bs) (i) =
    if i >= list-length bs then 0
-   else zig-max2 (zig-max-list-len ((list-at bs i).body)) (zig-max-list-len-branches bs (i + 1))
+   else let b = list-at bs i
+   in let here = zig-max2 (zig-max-list-len (b.guard)) (zig-max-list-len (b.body))
+   in zig-max2 here (zig-max-list-len-branches bs (i + 1))
 
   zig-max-list-len-stmts : List IRActStmt, Integer -> Integer
   zig-max-list-len-stmts (ss) (i) =


### PR DESCRIPTION
**Ours, from PR 81, and already in the tree.** Found 2026-08-25 when the ladder's census re-pin moved `dtls-fragment` from `match` to `refused`: `error: unused function parameter`. The refusal is the symptom; the defect under it returns a wrong number with no diagnostic.

`plugs-backlog.md` row **1.58** carries the full account. The short form:

A definition whose parameter shadows a top-level definition gets that parameter renamed to `_arg_<name>`, because zig forbids the shadow. `emit-zig-def`'s loop branch built its body context from `zig-push-tail-renames`, which covers the parameters the loop REASSIGNS and only those — so an invariant slot got no rename at all and fell through to the definition. `dtls-frag-loop` emits calls to `body()` and `msg_type()` where the source reads its own parameters; `dtls_msg_encode` in the same file takes the same two renamed parameters and reads them correctly (`cx_list_len(_arg_body)`). The non-loop emission bound the rename; the loop emission did not.

**Three hunks, and the second is not optional.**

1. The loop branch composes `zig-push-param-renames` under `zig-push-tail-renames`. The tail renames still win for the reassigned parameters because `zig-renamed-scan` reads from the end.
2. `zig-occurs-branches` walks a branch's **guard**. `zig-occurs` drives a discard — `_ = _arg_x;` for a parameter it believes unread — so a read the check can SEE means no discard, an unmentioned `_arg_x`, and zig refusing an unused parameter. That is what `dtls-fragment` did, and it means the obvious shape of this defect cannot return a wrong answer at all. The silent form needs a read the check is blind to, and a guard was one. Without this hunk, hunk 1 turns the wrong answer into a pointless-discard build error.
3. `zig-max-list-len-branches` walks it too. That walk's own prose says it mirrors `zig-occurs`, "same nodes, same reason to visit them, and the same consequence for a node it forgets", and it had the identical hole — shown before fixing: the same 40-element literal emits `@setEvalBranchQuota` in a branch body and none in a branch guard. That one fails loudly at zig compile time and no corpus program reaches it today. Neither walk descends into an effect handler's clauses, which is deliberate and now said out loud in the source: `emit-zig-expr` answers `@compileError` for any `IrHandle` carrying clauses.

**Verified in the order the ladder requires — the tier row first, and it had to fail.** `prim-tailcall` gained a `shadow-guard` row: bare metal 3 against the zig arm's 5, on a loop whose parameter `stop-at` is 3 and whose top-level `stop-at` is 100. Then the fix, then:

- the row green on both arms
- the 22-tier set green: 15 green, 7 noted, 0 unexpected — unchanged in shape from before the fix
- **14 of 14 rungs green** in a sweep, 1589 s
- **`dtls-fragment` back to `match`** in the corpus census, with 320 of the 325 clean programs byte-identical to the previous bank and **exactly one verdict moved**
- every ladder unit emitting byte-identical zig across the two native builds, which is how hunk 3 is shown to change nothing the sweep measures

**Three more programs in `codex/test/` carry the same collision.** `final-batch-test` and `lorawan-encode` had their emitted zig move too. Both stayed `refused` for unrelated reasons (`use of undeclared identifier 'Timestamp'`; a `std.Thread` startFn return type), so neither was ever run and neither could have shown the wrong answer — but the shape is not a peculiarity of `dtls-fragment`.

**Where the instrument was blind, since that is the reusable part.** `prim-tailcall` had exercised loop conversion since the day it was written and was green throughout: no row gave a loop a parameter that shadowed a top-level definition, so the whole class sat outside the tier set. What caught it was the depot's own corpus — a program written by someone with no knowledge of this plug, containing the collision by accident.

Ladder: `shadow-loop-rename`

🤖 Generated with [Claude Code](https://claude.com/claude-code)