### PR TITLE
zig plug: emit the prelude last, so an emitted file opens on the program instead of 813 fixed lines

### DIFF
--- a/build/check-zig-prelude-surface.ps1
+++ b/build/check-zig-prelude-surface.ps1
@@ -7,9 +7,14 @@
 # A by-eye extraction counted const and var only and missed every parameter,
 # which is how the surface was recorded at 66 when it is 102; this counts both.
 #
-# The prelude is emitted wholesale (ZigEmitter's opening concatenates
-# zig-prelude before any type or definition text), so the line-wise common
-# prefix of two or more emitted programs IS the prelude and nothing else.
+# The prelude is emitted wholesale and LAST, behind zig-postlude-banner, so it
+# is the common SUFFIX of every emitted program and the banner says exactly
+# where it starts. Anchor on the banner rather than on a longest-common run:
+# a run-length heuristic that lands in the wrong place still yields a surface,
+# and a surface that is too small passes silently. When the prelude led the
+# file this was a common-prefix scan, and moving the prelude turned it into a
+# 24-line scan of the tuple types -- 5 names derived instead of 98, all five
+# already reserved, so it printed OK.
 #
 # Not wired into any gate. Run it after changing zig-prelude.
 [CmdletBinding()]
@@ -26,7 +31,7 @@ if (-not $OutDir) { $OutDir = Join-Path $repo 'build-output\zig-prelude-surface'
 New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
 
 $names = $Subjects -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ }
-if ($names.Count -lt 2) { throw "need at least two subjects: the prelude is derived as their common prefix" }
+if ($names.Count -lt 2) { throw "need at least two subjects: their preludes are required to agree" }
 
 $emitted = @()
 foreach ($n in $names) {
@@ -38,18 +43,22 @@ foreach ($n in $names) {
     $emitted += $zig
 }
 
-$prefix = Get-Content $emitted[0]
-foreach ($f in $emitted | Select-Object -Skip 1) {
-    $l = Get-Content $f
-    $n = [Math]::Min($prefix.Count, $l.Count)
-    $k = 0
-    while ($k -lt $n -and $prefix[$k] -eq $l[$k]) { $k++ }
-    if ($k -eq 0) { throw "no common prefix: these programs do not share a prelude" }
-    $prefix = $prefix[0..($k - 1)]
+$bannerLine = '// THE PRELUDE. Everything ABOVE this line is the transpiled program.'
+$prelude = $null
+foreach ($f in $emitted) {
+    $l = @(Get-Content $f)
+    $i = -1
+    for ($k = 0; $k -lt $l.Count; $k++) { if ($l[$k] -eq $bannerLine) { $i = $k; break } }
+    if ($i -lt 0) { throw "no postlude banner in $f : the prelude is derived from it" }
+    $tail = $l[$i..($l.Count - 1)]
+    if ($null -eq $prelude) { $prelude = $tail }
+    elseif (($prelude -join "`n") -ne ($tail -join "`n")) {
+        throw "emitted preludes disagree between subjects ($f): the prelude is supposed to be identical in every file"
+    }
 }
 
 $surface = New-Object System.Collections.Generic.HashSet[string]
-foreach ($line in $prefix) {
+foreach ($line in $prelude) {
     foreach ($m in [regex]::Matches($line, '\b(?:const|var)\s+([A-Za-z_][A-Za-z0-9_]*)')) {
         [void]$surface.Add($m.Groups[1].Value)
     }
@@ -90,7 +99,7 @@ foreach ($s in $surface) {
 }
 
 "[zig-prelude-surface] prelude {0} lines over {1} programs; surface {2} names; zig-prelude-decls carries {3}" -f `
-    $prefix.Count, $emitted.Count, $surface.Count, $declared.Count
+    $prelude.Count, $emitted.Count, $surface.Count, $declared.Count
 
 if ($renamed.Count -gt 0) {
     "[zig-prelude-surface] RESIDUE ({0}): emitted binders that are the sanitized image of a reserved name. A user top-level spelled the same still collides." -f $renamed.Count

--- a/codex/plugs/plugs-backlog.md
+++ b/codex/plugs/plugs-backlog.md
@@ -3803,3 +3803,83 @@ not the plug: `elf-bytes.wasm` builds and runs, but its wire is a
 code/data/func-table payload, not a CDX, and nothing emits that from a
 browser -- the compiler has no ELF mode and `extract-x86-output.ps1` is one
 of the four dead harnesses.
+
+## 1.100 -- DONE 2026-08-28 (Claude, contributed by Steve Howell): the zig plug emitted its 37 KB runtime prelude ABOVE the program, so every emitted file opened on 813 identical lines
+
+`emit-zig-chapter` built `zig-prelude & types-text & defs-text & zig-main`.
+The prelude is 37,409 bytes of fixed runtime support -- the bump allocator and
+its heap, the list and text builtins, the CCE tables, the deck -- byte
+identical in every file the plug produces, and the transpiled program began
+past line 840. It now comes LAST, behind `zig-postlude-banner`, which names
+what is below the line and says why.
+
+**The proportion is worse than it sounds.** In the plug's 589-program corpus
+the smallest emitted program is 38,219 bytes of which 37,409 is prelude: the
+program is 2% of its own file.
+
+Two reasons beyond reading comfort. A diff between two emitted programs now
+opens on what differs rather than on hundreds of identical lines; and the
+arbitrary transpiled code, which is where bugs live, is what a reader meets
+first.
+
+**Inert, and graded rather than argued.** Zig does not order declarations at
+container scope. All 589 already-emitted corpus programs were transformed --
+prelude moved below the program, banner inserted -- and both variants of each
+were compiled and run:
+
+    programs graded          589
+    build outcome agrees     589
+    of which built           202
+    zig diagnostics agree    589
+    ran both ways            202
+    output byte-identical    198
+    identical but for source positions in a panic backtrace     4
+    disagreements              0
+
+The four are bounds-check programs whose panic prints a backtrace naming
+source positions, which the move shifts by construction. Same exit status,
+same stdout, same panic message, same machine addresses in the trace.
+
+**And the compiler itself**, which no corpus program resembles in size --
+built both ways, then driven, the input produced once and handed to both
+builds:
+
+    zigemit     445,173 bytes   exit 0, 42,547 bytes out, byte-identical
+    codexir   1,924,806 bytes   exit 0, 18,350 bytes out, byte-identical
+    codexzig  2,276,581 bytes   exit 0, 41,596 bytes out, byte-identical
+
+**The transform was calibrated against real plug output before any of it was
+believed**: it reproduces the plug's own before/after pair for the `arith`
+sample byte for byte (40,941 -> 41,661, delta 720, all banner), so grading the
+transform over the corpus is grading the plug, and no plug rebuild was needed
+to do it. `postlude_verify.py` in the ladder repository.
+
+**Every byte of the transpiled compiler's 3,870-byte growth is accounted for**,
+checked rather than inferred: 720 the banner, 3,116 the new
+`zig-postlude-banner` constant transpiled into the emitted compiler, 34 the
+reordered concatenation in `emit-zig-chapter`. Undo those three differences in
+the 2,387,634-byte file and it is byte-identical to its predecessor.
+
+**It carries a repair it caused.** `build/check-zig-prelude-surface.ps1`
+derived the prelude as the line-wise common PREFIX of several emitted
+programs. With the prelude last that prefix is the emitted tuple types, and
+the check does not fail -- it reports a smaller surface and passes:
+
+    prelude 24 lines over 4 programs; surface 5 names; zig-prelude-decls carries 101
+    OK: every derived name is reserved.
+
+Five names checked where the surface is 98, all five already reserved, exit 0.
+Anchored on the banner instead, and the subjects' preludes are now REQUIRED to
+agree rather than silently truncated to whatever they share. It derives 97
+where the prefix scan derived 98; the one it drops is `d`, which was never a
+prelude name -- the prefix ran past the prelude into `Tup4`'s comptime
+parameters and picked it up by accident.
+
+**What it is not.** Not a fix; nothing was wrong. It is the small half of a
+larger measurement: nothing uses the whole prelude. The greediest program in
+the corpus reaches 55 of its 93 top-level declarations and the median far
+fewer, so most of those 37 KB could be DROPPED per program rather than merely
+moved. Moving it first is worth doing alone and puts the shaking change at the
+same seam.
+
+Renumber freely if 1.100 collides with anything in flight.

--- a/codex/plugs/zig/ZigEmitter.codex
+++ b/codex/plugs/zig/ZigEmitter.codex
@@ -67,10 +67,17 @@ Section: Keywords and Sanitization
  name the prelude uses PRIVATELY is reserved for the whole program just as
  firmly as one it declares. That half is why this list is long and why it
  cannot be maintained by eye: `build/check-zig-prelude-surface.ps1` derives
- the surface from emitted output, as the line-wise common prefix of several
- programs, and counts parameters and captures as well as const and var. It
- refuses when a derived name is missing here. Run it after any change to
- zig-prelude.
+ the surface from emitted output, anchored on zig-postlude-banner and reading
+ to the end of the file, and counts parameters and captures as well as const
+ and var. It refuses when a derived name is missing here. Run it after any
+ change to zig-prelude.
+
+ The list is the UNION over the whole prelude and stays that way. A future
+ that emits only the parts a program reaches must not narrow it to the parts
+ that program got: the cost of keeping a name reserved for a program that
+ never sees it is one spurious underscore, and the cost of narrowing is that
+ the same Codex source emits a different spelling depending on which builtins
+ it happened to touch.
 
   zig-prelude-decls : List Text = ["std", "main", "cx_entry", "cx_heap_mem", "cx_heap_reserve", "cx_heap_vtable", "cx_hp", "cx_gpa", "cx_dptr", "cx_bivy", "cx_nest", "cx_deck_base", "cx_deck_hw", "cx_deck_top", "cx_deck_best", "cx_deck_stride", "cx_deck_armed", "cx_deck_slack",
    "a", "A", "acc", "al", "alignment", "ascii", "b", "B", "b0", "base",

--- a/codex/plugs/zig/ZigEmitter.codex
+++ b/codex/plugs/zig/ZigEmitter.codex
@@ -3759,6 +3759,26 @@ Section: Chapter Emission
   zig-entry-refusal =
    "@compileError(\"zig plug: opening returns a type this plug cannot print at the entry\")"
 
+ The banner between the program and the prelude. It lives here rather than
+ inside zig-prelude because placement is emit-zig-chapter's concern, and
+ because build/check-zig-prelude-surface.ps1 derives the reserved-name list
+ from zig-prelude and should not have to read past a comment to do it.
+
+  zig-postlude-banner : Text =
+   "\n"
+   & "// ========================================================================\n"
+   & "// THE PRELUDE. Everything ABOVE this line is the transpiled program.\n"
+   & "//\n"
+   & "// What follows is fixed runtime support, emitted into every file this plug\n"
+   & "// produces and identical in all of them: the bump allocator and its heap,\n"
+   & "// the list and text builtins, the CCE tables, the deck.\n"
+   & "//\n"
+   & "// It is at the BOTTOM so that the code you came to read is the first thing\n"
+   & "// in the file, and so a diff between two emitted programs opens on what\n"
+   & "// differs rather than on hundreds of identical lines. Zig does not order\n"
+   & "// declarations at container scope, so this costs nothing.\n"
+   & "// ========================================================================\n\n"
+
   zig-prelude : Text =
    "const std = @import(\"std\");\n\n"
    & "// cx_gpa and the heap it allocates from live beside the buffer\n"
@@ -3901,6 +3921,6 @@ Section: Chapter Emission
    }
    in let types-text = emit-zig-type-defs type-defs 0
    in let defs-text = emit-zig-defs (m.defs) 0 ctx
-   in zig-prelude & types-text & defs-text & zig-main opening-entry-point (m.defs)
+   in types-text & defs-text & zig-main opening-entry-point (m.defs) & zig-postlude-banner & zig-prelude
 
 Page 1


### PR DESCRIPTION
# PR body draft — zig plug: emit the prelude last

Branch `prelude-last`, rebased clean onto `968d4600` (Update 52) with no
stack under it.

**On the base, stated narrowly:** Update 52 does not touch
`codex/plugs/zig/` -- zero lines -- and the rebase was clean. That is all we
claim about it. The measurements below were taken against emitted output from
an earlier toolchain and have not been re-taken at this base; U52's compiler
changes could change what the plug emits. It does not affect what is being
graded, because "does zig care where the prelude sits" is a property of zig
and of the file's shape rather than of which Update produced the file. The
byte counts are the exception and are keyed to the files actually measured.

`Ladder: postlude-corpus-589`

---

## What it changes

`emit-zig-chapter` emitted

```
zig-prelude & types-text & defs-text & zig-main ...
```

so every file the zig plug produces opens with **37,409 bytes — 813 lines —
of fixed runtime support**, byte-identical in all of them, and the transpiled
program starts at line 840. Reversed:

```
types-text & defs-text & zig-main ... & zig-postlude-banner & zig-prelude
```

The program comes first; the prelude follows it behind a banner that says
what is below the line and why.

Zig does not order declarations at container scope, so this is inert.

## Why, beyond readability

- A diff between two emitted programs now opens on **what differs**, instead
  of on hundreds of identical prelude lines.
- The arbitrary transpiled code — which is where bugs are — is what a reader
  meets first. The prelude is fixed text that is the same in every file.
- The proportion is worse than it sounds. In the plug's 589-program corpus
  the *smallest* emitted program is 38,219 bytes of which 37,409 is prelude:
  **the program is 2% of its own file.**

`zig-postlude-banner` lives at the concatenation site rather than inside
`zig-prelude`, because placement is `emit-zig-chapter`'s concern and because
`build/check-zig-prelude-surface.ps1` derives its reserved-name list from
`zig-prelude` and should not have to read past a comment to do it.

## Evidence

All 589 already-emitted corpus programs were transformed -- prelude moved
below the program, banner inserted -- and both variants of each were compiled
and run. Full log in `outbound/MEASURED-prelude-last.log`.

```
programs graded          589
build outcome agrees     589
of which built           202
zig diagnostics agree    589
ran both ways            202
output byte-identical    198
identical but for source positions in a panic backtrace     4
disagreements              0
```

The four are bounds-check programs whose panic prints a backtrace naming
source positions, which the move shifts by construction. Same exit status,
same stdout, same panic message, and the same machine addresses in the trace.

### And the compiler itself

No corpus program resembles these in size -- 4.6 MB against a 42 KB median.
Built both ways, then DRIVEN: each native reads Codex on stdin and answers on
stderr, and the input was produced once and handed to both builds.

```
zigemit     445,173 bytes   exit 0, 42,547 bytes out, byte-identical: YES
codexir   1,924,806 bytes   exit 0, 18,350 bytes out, byte-identical: YES
codexzig  2,276,581 bytes   exit 0, 41,596 bytes out, byte-identical: YES
```

### How this was graded without building the plug

The change is a pure text reordering, so the reordering was done outside the
plug and then PROVED to be the plug's: it reproduces the plug's own
before/after pair for the `arith` sample byte for byte (40,941 -> 41,661,
delta 720, all banner), taken from `codex-zig-transpiler`'s history at
`8595322` and `daf36cf`. With that calibration, grading the transform over the
corpus is grading the plug, and no two native builds and two transpiles were
needed to say so.

### The repair it carries, which it caused

`build/check-zig-prelude-surface.ps1` derived the prelude as the line-wise
common PREFIX of several emitted programs. With the prelude last that prefix
is the emitted tuple types -- and the check does not fail, it reports a
smaller surface and passes:

```
[zig-prelude-surface] prelude 24 lines over 4 programs; surface 5 names; zig-prelude-decls carries 101
[zig-prelude-surface] OK: every derived name is reserved.
```

Five names checked where the real surface is 98, all five already reserved,
exit 0. Not a refusal -- a green light over a check that had stopped looking.
Anchored on the banner instead, and the subjects' preludes are now REQUIRED to
agree rather than silently truncated to whatever they happen to share. It
derives 97 where the prefix scan derived 98; the one it drops is `d`, which
was never a prelude name -- the prefix ran past the prelude into `Tup4`'s
comptime parameters and picked it up by accident.

The prose above `zig-prelude-decls` described that same prefix derivation and
is repointed. It also now states the rule the list has always followed
implicitly: it is the UNION over the whole prelude, and must stay that way
even if the plug someday emits only the parts a program reaches -- otherwise
the spelling of a user's local starts depending on which builtins the program
happened to touch.

We swept the rest of the tree for the same assumption. `check-zig-prelude-surface.ps1`
is the only positional dependency: `plug-oracle-test.ps1`, `check-plug-guards.ps1`,
`check-plug-builtins.ps1` and `quire-map.ps1` mention a prelude only in prose
or about other plugs.

### Every byte of the transpiler's output accounted for

`codex-zig-transpiler` transpiles the Codex compiler through this plug, so it
emits the change *and is changed by it*. Its emitted zig grew 3,870 bytes,
and the growth is exactly three things:

| | bytes |
|---|---|
| the banner, emitted into the file | 720 |
| `fn zig_postlude_banner()` — the new constant, transpiled | 3,116 |
| `fn emit_zig_chapter()` — the reordered concatenation | 34 |
| | **3,870** |

Checked rather than inferred: undo those three differences in the 2,387,634-byte
after-file and it is **byte-identical** to the before-file, with the prelude
back on top. Nothing else in 2.3 MB moved.

The fixed point holds at this revision — the transpiler still re-emits its own
bundle byte-identically — and the `arith` sample transpiles, builds, runs and
matches all nine lines of its expected output.

## What this is not

It is not a fix for anything. Nothing was wrong; the file was just upside
down for a reader. It is also the small half of a larger idea we are costing
out separately: **nothing uses the whole prelude.** The greediest program in
the corpus uses 55 of its 93 top-level declarations and the median far fewer,
so most of those 37 KB could be dropped per program rather than merely moved.
Moving it first is worth doing on its own, and it makes the shaking change a
one-line edit at the same seam.

Renumber the backlog row freely if `1.99` collides with anything in flight.
