### PR TITLE
zig plug: emit real-to-int and real-from-int, the f64 conversions

### DIFF
--- a/codex/plugs/plugs-backlog.md
+++ b/codex/plugs/plugs-backlog.md
@@ -4245,3 +4245,103 @@ PR 98's third file was `codex/compiler/IR/Lowering.codex`, deleting three
 `is NoExpectTy` arms each shadowed by an identical `is ErrorTy | NoExpectTy`.
 **Already landed as fester 20398** and the file has moved twice since under
 blu's COMPILER-32, so that hunk is dropped here rather than reapplied.
+
+## 2.06 -- DONE 2026-08-29 (Claude, contributed by Steve Howell): the zig plug had no emitter for `real-to-int` or `real-from-int`, so no transpiled program could convert between Real and Integer -- or report a computed Real at all
+
+`ZigBuiltinEmitter` carried 69 entries and, of the whole real-conversion family,
+only `bits-to-real-approx`. Both directions of the f64 pair fell through to the
+generic refusal:
+
+    error: zig plug: no emitter for real-to-int
+    error: zig plug: no emitter for real-from-int
+
+They are declared in `Types/Builtins.codex:281-282` with types
+`Integer -> Real` and `Real -> Integer`, they have bare-metal emitters, and
+arm64, riscv and wgsl all implement them. This arm did not.
+
+### The consequence that cost the most was not the conversion
+
+`show` on a Real is refused by this plug -- deliberately, and correctly: it needs
+a `__real_to_text` the plug does not have, and `std.fmt` would agree with bare
+metal on some values and not others. That refusal is right and is not touched
+here.
+
+But with the conversions ALSO missing there was no way out for a Real at all. It
+could not be printed, and it could not be turned into something that could. **A
+failing test could say WHERE it failed and never WHAT it computed.** Measured
+cost, while porting a 3,400-line zig program to Codex: a numeric tolerance had to
+be found by BINARY-SEARCHING it -- tighten, rebuild, see which seams go red --
+instead of read off a diff; and one wrong coordinate had to be diagnosed by
+re-simulating the whole computation in f64 in a separate zig program, to
+establish that 20.606868 against an expected 20.606842 was floating-point width
+and not a bug.
+
+Both retire with this row. `real-to-int (x * 1000.0)` is a scaled-integer dump
+and a plain diff.
+
+A second consequence, smaller but constant: no counted loop could widen its
+index, since `0.0 + i` is a type error (CDX2001) and there was no conversion
+either. Every `i / n * two-pi` had to carry a Real accumulator threaded beside
+the Integer counter.
+
+### What the emission is, and why the guards are not decoration
+
+Bare metal is `emit-real-from-int-builtin` / `emit-real-to-int-builtin` at
+`Emit/X86_64Builtins.codex:1663-1679`: `cvtsi2sd` one way, `cvttsd2si` the other.
+
+`cvttsd2si` truncates toward zero and answers x86's "integer indefinite" --
+INT64_MIN -- for a NaN, for an infinity, and for anything whose truncation will
+not fit i64. Zig's `@intFromFloat` truncates the same way **but is UNDEFINED out
+of range**, so a bare cast is not a different answer from bare metal, it is no
+answer at all. `cx_real_to_int` therefore carries three guards, which are the
+mirror of the hardware's own behaviour. 2^63 is exact in f64, so both bounds are
+exact and the comparisons catch the infinities on the way past.
+
+Checked against the instructions themselves rather than against the manual, by
+inline asm, over 31 values: **zero disagreements**, including NaN, both
+infinities, +/-1e300, exactly +/-2^63, the largest f64 below 2^63, the next
+representable below -2^63, and the 2^53+1 rounding region.
+
+### Scope: the f64 pair only
+
+The `real-approx-*` family is deliberately untouched. Every plug in the house
+carries Real as f64 whatever width the type asked for -- the wasm plug states it
+as policy -- while bare metal picks the opcode by type and emits `ADDSS` for
+`Real approximate`. Filling the f32 conversions would make that divergence
+observable for the first time, which is a much larger conversation and belongs in
+its own row with its own repro. This change cannot make it worse and does not
+approach it.
+
+### The parameter names add no reserved surface
+
+A prelude function's parameter names are part of the plug's reserved surface: a
+program whose top-level name collides with one gets a `const` shadowed by a
+parameter, which zig forbids. So both helpers take `v`, which
+`zig-prelude-decls` already carries and other prelude functions already use.
+The two function names are the only surface this adds.
+
+    parts    96 -> 98      declarations 96 -> 98, every one named by a part
+    surface  129 -> 131    the two new function names, both reserved
+    missing  none, measured against an unmodified tree as control
+
+### What has been measured, and what has not
+
+The zig arm is measured. `codex/test/ops/real-int-conversions.codex` is new
+here and its eleven lines come back byte-identical to its `.expected` through
+the transpiler; no emitted file carries a missing-emitter marker. The
+transpiler's own fixed point holds on this branch -- both passes 2,445,785
+bytes, identical -- and a 3,400-line ported program regrades clean on it.
+
+**Bare metal is measured, and the `.expected` is a reading rather than a
+claim.** The seed compiled and ran both tests under QEMU at seed `B066CEB5`:
+all eleven lines byte-identical to `real-int-conversions.expected`, truncation
+direction and both range-edge lines included. So the two arms agree on every
+line -- the same file also matches through the transpiler.
+
+**The control is what makes that worth anything.**
+`codex/test/ops/real-saturating-finite` ran in the same pass on the same rig.
+Its `.expected` is upstream's, committed in `b643e7cb` on 2026-08-20, and it
+exercises both builtins under test. It came back byte-identical, so the rig
+that produced the new answer is checked against an answer it could not have
+influenced. A rig that emits plausible output is otherwise indistinguishable
+from a correct one.

--- a/codex/plugs/zig/ZigEmitter.codex
+++ b/codex/plugs/zig/ZigEmitter.codex
@@ -103,6 +103,7 @@ Section: Keywords and Sanitization
    "CxFn3", "CxFn4", "CxList", "cx_ll_empty", "cx_ll_push", "cx_ll_of",
    "cx_ll_concat", "cx_ll_cons", "cx_ll_insert_at", "cx_ll_with_capacity",
    "cx_text_compare", "cx_text_to_double_bits", "cx_bits_to_real_approx",
+   "cx_real_to_int", "cx_real_from_int",
    "cx_char_to_text", "cx_char_encode", "cx_list_len", "cx_list_at",
    "cx_text_len", "cx_char_at", "cx_text_dup", "cx_substring", "cx_ipow",
    "cx_shl", "cx_shr", "cx_heap_base", "cx_buf_want", "cx_frontier_crosses",
@@ -1078,6 +1079,8 @@ Section: Builtin Emitter
     ZigBuiltinEmitter { name = "print-text", emit = \args ctx d ty -> "cx_print(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "text-to-double-bits", emit = \args ctx d ty -> "cx_text_to_double_bits(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "bits-to-real-approx", emit = \args ctx d ty -> "cx_bits_to_real_approx(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
+    ZigBuiltinEmitter { name = "real-from-int", emit = \args ctx d ty -> "cx_real_from_int(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
+    ZigBuiltinEmitter { name = "real-to-int", emit = \args ctx d ty -> "cx_real_to_int(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "print-error", emit = \args ctx d ty -> "cx_print_line(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "print-error-uni", emit = \args ctx d ty -> "cx_print_line(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "show", emit = \args ctx d ty -> zig-show-arg (list-at args 0) ctx d },
@@ -3887,6 +3890,12 @@ Section: Chapter Emission
   zig-p-cx-bits-to-real-approx : List ShakeFrag
   zig-p-cx-bits-to-real-approx = [ShakeLit "// real-f32 on bare metal is f32 bits in a general register (a movd\n// round-trip, emit-bits-to-real-approx-builtin); Real is f64 here, and\n// widening the named f32 value is exact.\nfn ", ShakeUse "cx_bits_to_real_approx", ShakeLit "(bits: i64) f64 {\n    return @floatCast(@as(f32, @bitCast(@as(u32, @truncate(@as(u64, @bitCast(bits)))))));\n}\n"]
 
+  zig-p-cx-real-from-int : List ShakeFrag
+  zig-p-cx-real-from-int = [ShakeLit "// cvtsi2sd on bare metal (emit-real-from-int-builtin): a signed i64 to\n// f64 in the default rounding mode, which is round-to-nearest-even.\n// @floatFromInt is that same conversion -- exact below 2^53 and correctly\n// rounded above it -- so the two arms agree at every magnitude.\nfn ", ShakeUse "cx_real_from_int", ShakeLit "(n: i64) f64 {\n    return @floatFromInt(n);\n}\n"]
+
+  zig-p-cx-real-to-int : List ShakeFrag
+  zig-p-cx-real-to-int = [ShakeLit "// cvttsd2si on bare metal (emit-real-to-int-builtin): truncate toward\n// zero, and answer x86's \"integer indefinite\" -- INT64_MIN -- for a NaN,\n// for an infinity, and for anything whose truncation will not fit i64.\n// Zig's @intFromFloat truncates the same way but is UNDEFINED out of\n// range, so these guards are the mirror of what the hardware actually\n// answers rather than decoration: without them the out-of-range cases are\n// not merely a different answer from bare metal, they are no answer at\n// all. 2^63 is exact in f64, so both bounds are exact and the comparisons\n// catch the infinities on the way past.\nfn ", ShakeUse "cx_real_to_int", ShakeLit "(v: f64) i64 {\n    if (v != v) return -9223372036854775808;\n    if (v >= 9223372036854775808.0) return -9223372036854775808;\n    if (v < -9223372036854775808.0) return -9223372036854775808;\n    return @intFromFloat(v);\n}\n"]
+
   zig-p-cx-char-to-text : List ShakeFrag
   zig-p-cx-char-to-text = [ShakeLit "// A char is a CCE code and text is CCE, so making text from a char is\n// ONE raw byte, the way bare metal does: emit-char-to-text-builtin stores\n// the code with mov-store-byte, length 1, no framing, truncating silently\n// past 255. Byte-wise text rebuilds (ir-quote walks char-code-at /\n// code-to-char / char-to-text over every byte) rely on that identity to\n// pass CCE frame bytes through untouched; framing or converting here\n// corrupts the wire.\nfn ", ShakeUse "cx_char_to_text", ShakeLit "(c: i64) []const u8 {\n    const b = ", ShakeUse "cx_gpa", ShakeLit ".alloc(u8, 1) catch @panic(\"oom\");\n    b[0] = @truncate(@as(u64, @bitCast(c)));\n    return b;\n}\n"]
 
@@ -4144,6 +4153,8 @@ Section: Chapter Emission
     ShakePart { name = "cx_text_compare", frags = zig-p-cx-text-compare },
     ShakePart { name = "cx_text_to_double_bits", frags = zig-p-cx-text-to-double-bits },
     ShakePart { name = "cx_bits_to_real_approx", frags = zig-p-cx-bits-to-real-approx },
+    ShakePart { name = "cx_real_from_int", frags = zig-p-cx-real-from-int },
+    ShakePart { name = "cx_real_to_int", frags = zig-p-cx-real-to-int },
     ShakePart { name = "cx_char_to_text", frags = zig-p-cx-char-to-text },
     ShakePart { name = "cx_char_encode", frags = zig-p-cx-char-encode },
     ShakePart { name = "cx_list_len", frags = zig-p-cx-list-len },

--- a/codex/plugs/zig/run.ps1
+++ b/codex/plugs/zig/run.ps1
@@ -13,12 +13,30 @@ $OutDir  = Join-Path $PSScriptRoot 'build-output'
 $IrFile  = Join-Path $OutDir 'last-run.ir'
 $LogFile = Join-Path $OutDir 'run.log'
 
+# The directory this writes its IR and its log into. Nothing else created it,
+# so in a fresh checkout compile.ps1 was asked to write a log into a directory
+# that does not exist and the failure surfaced as "IR compile failed; see
+# <that log>" -- naming a file it had just been unable to create.
+New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+
+# compile.ps1 wants the SELF-HOSTED kernel that build.ps1 produces, and refuses
+# with "run build.ps1 first, or pass -Kernel seed\Codex.cdx" when it is absent.
+# Take it at its word: use the self-hosted kernel when there is one and fall
+# back to the seed when there is not, rather than requiring a full build.ps1
+# before the plug can be run at all. The plug's output does not depend on which
+# compiler produced the IR it is handed.
+$Kernel     = Join-Path $Repo 'build-output' 'bare-metal' 'Codex.cdx'
+$KernelArgs = @()
+if (-not (Test-Path $Kernel)) {
+    $KernelArgs = @('-Kernel', (Join-Path $Repo 'seed' 'Codex.cdx'))
+}
+
 # -Passes 'text-plug' is what a SOURCE plug must receive: the default pipeline
 # inlines, and an inlined call site never reaches the emitter at all. Measured
 # on plug-oracle-arith, the default inlines the one call whose arguments are
 # both literals and both list-literal helpers, so the emitter is graded on a
 # program it is not handed in service (plugs-backlog 1.15).
-& pwsh -NoProfile -File (Join-Path $Repo 'build\compile.ps1') -Src $Src -Out $IrFile -Log $LogFile -IrCce -Passes 'text-plug' 2>&1 | Out-Null
+& pwsh -NoProfile -File (Join-Path $Repo 'build\compile.ps1') -Src $Src -Out $IrFile -Log $LogFile -IrCce -Passes 'text-plug' @KernelArgs 2>&1 | Out-Null
 if ($LASTEXITCODE -ne 0 -or -not (Test-Path $IrFile)) {
     [Console]::Error.WriteLine("FAIL: IR compile failed; see $LogFile")
     exit 4

--- a/codex/test/ops/real-int-conversions.codex
+++ b/codex/test/ops/real-int-conversions.codex
@@ -1,0 +1,38 @@
+Chapter: RealIntConversions
+
+  cites Foreword chapter Console
+
+ real-from-int and real-to-int, the f64 pair. Bare metal emits cvtsi2sd and
+ cvttsd2si. Every answer below is a whole number, which `show` reads exactly,
+ so no line depends on how a Real prints.
+
+ TRUNCATION IS TOWARD ZERO, and the negative lines are what say so. A floor
+ would answer -3 where this answers -2, and -1 where this answers 0, so an
+ emitter reaching for a rounding instruction is distinguished rather than
+ merely detected.
+
+ THE RANGE EDGE IS THE LAST TWO LINES, and it is the reason this pair needs
+ more than a cast. INT64_MAX is not representable in f64: it converts to
+ exactly 2^63, which is one past what an i64 holds, so converting back cannot
+ answer INT64_MAX. cvttsd2si answers x86's "integer indefinite", INT64_MIN.
+ The line under it is the largest f64 strictly below 2^63, which converts back
+ exactly and must NOT be indefinite -- the two together pin the boundary from
+ both sides, and an emitter that saturates instead of answering indefinite
+ fails the first while passing the second.
+
+Section: Report
+
+  opening : [Console] Nothing
+  opening = act
+    print-line-uni ("round 0 " & show (real-to-int (real-from-int 0)))
+    print-line-uni ("round 42 " & show (real-to-int (real-from-int 42)))
+    print-line-uni ("round -42 " & show (real-to-int (real-from-int (0 - 42))))
+    print-line-uni ("round 1000000 " & show (real-to-int (real-from-int 1000000)))
+    print-line-uni ("exact 2p53 " & show (real-to-int (real-from-int 9007199254740992)))
+    print-line-uni ("trunc 2.75 " & show (real-to-int 2.75))
+    print-line-uni ("trunc -2.75 " & show (real-to-int (0.0 - 2.75)))
+    print-line-uni ("trunc 0.75 " & show (real-to-int 0.75))
+    print-line-uni ("trunc -0.75 " & show (real-to-int (0.0 - 0.75)))
+    print-line-uni ("edge intmax " & show (real-to-int (real-from-int 9223372036854775807)))
+    print-line-uni ("edge below " & show (real-to-int (real-from-int 9223372036854774784)))
+  end

--- a/codex/test/ops/real-int-conversions.expected
+++ b/codex/test/ops/real-int-conversions.expected
@@ -1,0 +1,11 @@
+round 0 0
+round 42 42
+round -42 -42
+round 1000000 1000000
+exact 2p53 9007199254740992
+trunc 2.75 2
+trunc -2.75 -2
+trunc 0.75 0
+trunc -0.75 0
+edge intmax -9223372036854775808
+edge below 9223372036854774784


### PR DESCRIPTION
Claude here, working with Steve Howell on the zig phase-oracle ladder.

`real-from-int : Integer -> Real` and `real-to-int : Real -> Integer` are declared in `Types/Builtins.codex:281-282`, have bare-metal emitters at `Emit/X86_64Builtins.codex:1663-1679`, and are implemented by the arm64, riscv and wgsl plugs. The zig plug carries only `bits-to-real-approx` of the whole real-conversion family, so both directions fall through to the generic refusal. This adds the two emitters and their two prelude parts.

Register entry: `codex/plugs/plugs-backlog.md` 2.06. Ladder tag `reals-u53`.

## Why the guards are not decoration

Bare metal is `cvtsi2sd` one way and `cvttsd2si` the other. `cvttsd2si` truncates toward zero and answers x86's "integer indefinite" — `INT64_MIN` — for a NaN, for an infinity, and for anything whose truncation will not fit `i64`. Zig's `@intFromFloat` truncates the same way but is **undefined** out of range, so a bare cast is not a *different* answer from bare metal, it is *no* answer at all. The three comparisons in `cx_real_to_int` are what make the two arms agree at every magnitude; 2^63 is exact in f64, so both bounds are exact and the comparisons catch the infinities on the way past.

Both helpers take `v` rather than a fresh name: a prelude parameter is part of the plug's reserved surface, and `v` is already in `zig-prelude-decls`. The two function names are the only surface this adds.

## Scope

**The f64 pair only.** `real-approx-*` is untouched. Every plug carries `Real` as f64 whatever the type asked, while bare metal emits `ADDSS` for `Real approximate`, so filling the f32 conversions would make that divergence observable for the first time. That belongs in its own row.

## What it unblocks, counted over your own tests

Transpiling every program under `codex/test/` (recursively, excluding `apps/`) through the plug and counting how many hit each refusal — 1,229 programs on plain Update 53, 1,233 with our outbound work applied:

| refusal | Update 53 | with this |
|---|---|---|
| `no emitter for real-to-int` | **17** programs | **0** |
| `no emitter for real-from-int` | **15** programs | **0** |

Counts are programs, not occurrences. For scale, the untouched gaps do not move at all across the same pair — `poke-32` 140 both sides, `peek-32` 136, `poke-byte` 112 — so the change is reaching what it claims and nothing else.

The measurement had all of our open PRs applied at once, so it says these two markers cleared; nothing else in that branch touches either builtin.

## The test, and what settles it

`codex/test/ops/real-int-conversions` is new and covers what the existing tests do not: the truncation **direction**, which a floor emitter gets wrong on the negative lines, and the range edge from both sides. `INT64_MAX` is not representable in f64 and converts to exactly 2^63, so converting back cannot answer `INT64_MAX` and must answer indefinite; the largest f64 below 2^63 converts back exactly and must not. An emitter that saturates fails the first and passes the second.

**Both arms agree on all eleven lines.** The seed compiled and ran it under QEMU at seed `B066CEB5` and answered byte-identically to its `.expected`; the same file matches through the transpiler.

**The control is what makes that worth anything.** The same pass re-ran `codex/test/ops/real-saturating-finite`, whose `.expected` is yours from `b643e7cb` and which exercises both builtins. It came back byte-identical, so the rig that produced the new answer is checked against one it could not have influenced.

## The second commit

`run.ps1` is a separate, smaller thing riding along because it is what let the surface check run at all. It writes its IR and log into `plugs/zig/build-output` and nothing creates that directory, so `compile.ps1` is handed a log path it cannot open and the failure reads `FAIL: IR compile failed; see <that log>` — naming the file it had just been unable to create. And `compile.ps1` wants the self-hosted kernel `build.ps1` produces, refusing when it is absent; `run.ps1` passed neither, so it now uses the self-hosted kernel when one exists and the seed when it does not. The plug's output does not depend on which compiler produced the IR it is handed.

## What we have not done

We do not run the non-zig plugs, and this touches none of them. Your battery is the arbiter for the new test.


