### PR TITLE
compiler: three of the four reserved fixes, and why the fourth does not work

### DIFF
--- a/codex/compiler/IR/Lowering.codex
+++ b/codex/compiler/IR/Lowering.codex
@@ -1314,13 +1314,32 @@ Section: Collections and Act
 
   lower-empty-list : CodexType, LowerCtx, SourceSpan -> IRExpr
   lower-empty-list (ty) (ctx) (sp) =
-   let resolved = deep-resolve (ctx.ust) ty
+   let resolved = empty-list-element-source (deep-resolve (ctx.ust) ty) ctx sp
    in when resolved
     is LinkedListTy (e) ->
      let ll-ty = deck-record (LinkedListTy e)
      in deck-record (IrApply (deck-record (IrName "__linked-list-empty" (deck-record (FunTy int-ty-default empty-row ll-ty)) sp)) (deck-record (IrIntLit 0 sp)) ll-ty sp)
     is ListTy (e) -> deck-record (IrList [] e sp)
     is otherwise -> deck-record (IrList [] ErrorTy sp)
+
+ WHEN THE CONTEXT SAYS NOTHING, ASK THE CHECKER. An empty list literal has no
+ element to answer from, so its element type comes from somewhere else
+ entirely -- a declared parameter it is passed to, a signature one line down.
+ The checker solves that and files it under the literal's span; `infer-list`
+ does the filing. This asks for it, and ONLY when the context supplied no list
+ type of its own: when it did, `resolved` is what it always was and every line
+ below is unchanged.
+
+ Without this the `is otherwise` arm emits `ErrorTy` as the element type of a
+ list the compiler had fully resolved, and that reaches a plug as
+ `(list error)` on a program reported clean.
+
+  empty-list-element-source : CodexType, LowerCtx, SourceSpan -> CodexType
+  empty-list-element-source (ctx-ty) (ctx) (sp) =
+   when ctx-ty
+    is ListTy (e) -> ctx-ty
+    is LinkedListTy (e) -> ctx-ty
+    is otherwise -> deep-resolve (ctx.ust) (lookup-expr-type (ctx.ust) sp)
 
   lower-nonempty-list : List AExpr, CodexType, LowerCtx, SourceSpan -> IRExpr
   lower-nonempty-list (elems) (ty) (ctx) (sp) =

--- a/codex/compiler/IR/Lowering.codex
+++ b/codex/compiler/IR/Lowering.codex
@@ -1347,10 +1347,41 @@ Section: Collections and Act
    in let from-context = when resolved
       is ListTy (e) -> e
       is otherwise -> ErrorTy
+   in let witness = ir-expr-type (lower-expr (list-at elems 0) NoExpectTy ctx)
    in let elem-ty = when from-context
-      is ErrorTy | NoExpectTy -> ir-expr-type (lower-expr (list-at elems 0) NoExpectTy ctx)
-      is otherwise -> from-context
+      is ErrorTy | NoExpectTy -> witness
+      is otherwise -> if list-elem-prefers-witness from-context witness then witness else from-context
    in deck-record (IrList (for e in elems -> lower-expr e elem-ty ctx) elem-ty sp)
+
+ The elements used to be consulted ONLY when the context said nothing at all,
+ so a context that said something WRONG won unopposed. At a polymorphic call
+ the context is the callee's declared element type with its type variables
+ still in it, and those variables belong to the CALLEE's scope, not to the
+ definition being lowered. `hamt-test` recorded a one-element list of
+ `HamtEntry (tvar 25)` whose element was a `HamtEntry (tvar 70)` and whose
+ target list was `(list (ctd "HamtEntry" (args (tvar 70))))`, inside a
+ definition that is `forall 70` -- and the unit binds no `forall 25` anywhere,
+ so the plug was asked to emit a variable that is declared nowhere.
+
+ This is the same fault `lambda-recorded-ty` twenty lines up already guards
+ against, in its own words: a node recording "the EXPECTED type it was
+ handed, which at a polymorphic call is the callee's declared parameter with
+ its type variables still in it".
+
+  list-elem-prefers-witness : CodexType, CodexType -> Boolean
+  list-elem-prefers-witness (from-context) (witness) =
+   if ty-has-typevars from-context == False then False
+   else if ty-has-error witness then False
+   else ty-admits-widening witness == False
+
+ Deliberately NOT `usable-witness-ty`, and the difference is one clause.
+ That predicate refuses any witness carrying type variables, which is right
+ for a branch join deciding whether to erase one. Here the answer is not to
+ erase a variable but to prefer the one that is BOUND at this site over one
+ that is not, so a witness of `HamtEntry (tvar 70)` inside `forall 70` has to
+ be allowed to win. The other two clauses are kept for the reasons they were
+ written: an `error` witness knows nothing, and a numeric witness must not
+ pin a literal that still has widening to do.
 
   lower-record : Name, List AFieldExpr, CodexType, LowerCtx, SourceSpan -> IRExpr
   lower-record (name) (fields) (ty) (ctx) (sp) =

--- a/codex/compiler/IR/LoweringTypes.codex
+++ b/codex/compiler/IR/LoweringTypes.codex
@@ -61,7 +61,39 @@ Section: Type Substitution
     is ListTy (pe) -> subst-from-list pe arg-ty target
     is FunTy (pp) (prow) (pr) -> subst-from-fun pp pr arg-ty target
     is TypeApply (pf) (pa) -> when arg-ty is TypeApply (af) (aa) -> let t2 = subst-type-vars-from-arg pf af target in subst-type-vars-from-arg pa aa t2 is otherwise -> target
+    is SumTy (pn) (pargs) (pctors) -> when arg-ty is SumTy (an) (aargs) (actors) -> subst-from-named (pn.value) (an.value) pargs aargs target is otherwise -> target
+    is RecordTy (pn) (pargs) (pfields) -> when arg-ty is RecordTy (an) (aargs) (afields) -> subst-from-named (pn.value) (an.value) pargs aargs target is otherwise -> target
+    is ConstructedTy (pn) (pargs) -> when arg-ty is ConstructedTy (an) (aargs) -> subst-from-named (pn.value) (an.value) pargs aargs target is otherwise -> target
+    is LinkedListTy (pe) -> when arg-ty is LinkedListTy (ae) -> subst-type-vars-from-arg pe ae target is otherwise -> target
+    is VectorTy (pw) (pe) -> when arg-ty is VectorTy (aw) (ae) -> subst-type-vars-from-arg pe ae target is otherwise -> target
+    is UnitTy (pn) (pe) -> when arg-ty is UnitTy (an) (ae) -> if pn.value == an.value then subst-type-vars-from-arg pe ae target else target is otherwise -> target
+    is LinearTy (pe) -> when arg-ty is LinearTy (ae) -> subst-type-vars-from-arg pe ae target is otherwise -> target
     is otherwise -> target
+
+ The seven arms above `otherwise` are every remaining variant that carries a
+ type child. Before them this walk knew `List a` and `a -> b` and nothing the
+ SUBJECT declares, so a variable inside a declared `Step a` could not be
+ learned from any position -- and `branch-recorded-ty` would reach here with
+ two concrete branches, a usable witness, and come away with nothing. The
+ asymmetry was the tell: `subst-type-var-in-target` below, which APPLIES a
+ substitution, walks every variant through `codex-type-map-children`; only
+ the LEARNING direction was blind.
+
+ The name guard on the three NAMED variants is not decoration. Positional
+ arguments of two different declared types have nothing to do with each
+ other, and learning `a := Integer` from an unrelated constructor that
+ happens to have one argument would be worse than learning nothing.
+
+  subst-from-named : Text, Text, List CodexType, List CodexType, CodexType -> CodexType
+  subst-from-named (pn) (an) (pargs) (aargs) (target) =
+   if pn == an then subst-from-tyargs pargs aargs target 0 else target
+
+  subst-from-tyargs : List CodexType, List CodexType, CodexType, Integer -> CodexType
+  subst-from-tyargs (ps) (as) (target) (i) =
+   if i >= list-length ps then target
+   else if i >= list-length as then target
+   else let t2 = subst-type-vars-from-arg (list-at ps i) (list-at as i) target
+   in subst-from-tyargs ps as t2 (i + 1)
 
   subst-from-list : CodexType, CodexType, CodexType -> CodexType
   subst-from-list (pe) (arg-ty) (target) =

--- a/codex/compiler/Types/TypeCheckerInference.codex
+++ b/codex/compiler/Types/TypeCheckerInference.codex
@@ -1211,6 +1211,14 @@ Section: Lint value-expression range analysis
     is otherwise -> infer-literal st kind
 
 Section: Infer List
+ An EMPTY list literal answers with a fresh variable, because it has no
+ element to answer from. Unification then solves that variable from wherever
+ the literal is used -- a declared parameter one line down is enough -- and
+ the answer is filed under the literal's span so lowering can ask for it.
+ Without the filing, `lower-empty-list` has only the CONTEXT's expectation,
+ and when nothing above supplies one it emits `ErrorTy` for an element type
+ the checker had resolved.
+
   infer-list : UnificationState, TypeEnv, List AExpr, SourceSpan, Integer -> CheckResult
   infer-list (st0) (env) (elems) (span) (depth) =
    let st = if list-length elems > max-list-literal-elems
@@ -1222,7 +1230,7 @@ Section: Infer List
      in CheckResult {
       inferred-type = fr-ty,
       effect-row = empty-row,
-      state = fr-st
+      state = record-expr-type fr-st span fr-ty
      }
     else let first = infer-expr-at st env (list-at elems 0) (depth + 1)
     in let (elems-row, st2) = unify-list-elems (first.state) env elems (first.inferred-type) 1 (list-length elems) (first.effect-row) depth


### PR DESCRIPTION
Claude here, working with Steve Howell on the zig phase-oracle ladder.

Update 53's open-items list asks for four fixes, RESERVED for us in the COMPILER-30 row with `DO NOT TAKE THESE UP`. **This sends three. The fourth does not work, and saying so is probably worth more than the three.**

Ladder tag: `second-compiler-pr-u53`. Rebased from the Update 52 pin onto `58b08c38`; compiler-only, +94/−4.

## The three

- **`subst-type-vars-from-arg`'s learning arms** — it could not learn a type variable from any user-declared parametric type, only from builtins, so a branch join kept a variable both of its branches had resolved.
- **The empty-list carrier** — `infer-list` answers an empty literal with a fresh type variable and never calls `record-expr-type`, so the solved element type is never filed under the literal's span and the wire carries `(list error)`.
- **`lower-nonempty-list`** — a list literal took its element type from the context even when the context was a type variable belonging to the *callee's* scope, while its own correctly-typed elements were ignored.

The third conflicted with COMPILER-32's work, which rewrote the same arm — both widening the sentinel test to `ErrorTy | NoExpectTy` and changing which sentinel is passed down. Resolved to our semantics in your convention; taking either side whole would have silently reverted the other.

## The fourth: measured, and withdrawn

The instance-method span site was our own diagnosis and it is wrong. We built it (`token-span (m.name)`), and measured it: **no parameter cell moved and both target programs stayed red.** A method lambda is a record field value, so its context supplies an expectation and COMPILER-30's arm never fires — the span cannot help it.

It is also not free. It perturbed variable numbering (`__lam_1`'s body went `tvar 516` to `tvar 511`) while moving nothing, so it would add noise to every future diff and buy nothing. We removed it on the standard you set for the ForExpr site: *a fix that nothing measures waits for an instrument.* This one had an instrument and failed it.

The real lead there is an instance dictionary's type argument being instantiated for one instance and not its sibling, which is our finding 65 and is not addressed here.

## The part we would rather you read than the patches

`roc-fold-empty` is in that list, but it comes back **refused**, not `match` — and the reason is the argument of this PR.

The COMPILER-30 row records our earlier report that it goes "markers to match". That was measured on the Update 52 pin. On Update 53 the empty-list fix works — the program leaves `markers` — and it immediately fails to build:

```
expected type 'i64', found 'CxFn3(*CxList(i64), i64, CxFn2(i64,i64,i64), i64)'
```

The IR binds `total` as a three-argument function and reads it back as an integer, in the same statement. One name, two types. **Bare metal produces the identical contradiction**, so this is not our rendering of it — we checked before reporting, because `native/codexir` is the compiler as our own plug renders it and reporting from it has misled us before.

The site is `lower-apply-lambda-chain`, and Update 53 changed exactly it:

```
-   in let fn-ty = build-curried-fun-ty arg-irs 0 n ty
+   in let want = expected-or-recorded-ty ty ctx sp
+   in let fn-ty = build-curried-fun-ty arg-irs 0 n want
```

`expected-or-recorded-ty` is PR 93's `lambda-expected-ty`, renamed and generalised — **the remedy for this family**. Applied to a new site, it produced a new instance of the family.

That is why we think the site-by-site approach has stopped converging. Counting the ones we have chased: the lambda (PR 93), the branch join, the empty list, the list literal, and now this. Each was diagnosed from scratch as though new. The general defect is not any of them — it is that **nothing requires a lowering site to carry what the checker solved**, so every site is a fresh chance to forget, and forgetting is silent.

## What it clears, counted over your own tests

Transpiling every program under `codex/test/` (recursively, excluding `apps/`) through the plug and counting how many hit each front-end refusal — 1,229 programs on plain Update 53, 1,233 with our outbound work applied:

| refusal | Update 53 | with this |
|---|---|---|
| `type variable T27 is not declared at this site` | 3 programs | **0** |
| `unresolved type variable T16 of __lam_1` | 4 programs | **1** |
| `type variable T25 is not declared at this site` | 3 programs | **1** |
| `no zig type for this codex type` | 3 programs | **1** |

**The residue is the point, not an embarrassment.** These fixes were always partial — the rows that go to one are what a separate, still-open gap explains, and they are now countable rather than asserted. For scale, gaps these fixes do not touch stay exactly put across the same pair: `poke-32` 140 both sides, `peek-32` 136.

The measurement had all of our open PRs applied at once. The plug-side ones in that branch add builtin emitters and cannot move a type-variable diagnostic.

## What would actually close it, and the honest problem with it

A property over the whole IR: *for every expression the checker resolved, does the wire carry the answer?* Not "no `error` on the wire" — an unsolved type variable is sometimes the honest answer, for a lambda that is never applied and whose parameter nothing constrains. The discriminator is whether the checker **computed** an answer the IR then failed to carry, which is mechanically checkable in one pass.

**The honest problem: you cannot run it.** The x86 reference and the C# DDC witness both erase types by construction, so neither can fail on a dropped one — this class is invisible to your gates by design, which is presumably why it keeps arriving from us. It has to be built on an arm that does not erase types, and that is ours.

So this is an offer, not a request. We have most of the parts already — a seven-case probe with `.expected` banked from bare metal, a wire reader with no emitter opinion in it, and a strict leg running the matrix end to end. If it would be useful, we will build it here and report the whole list at once instead of a sixth finding in six weeks.



