### PR TITLE
zig plug: drop a match arm an earlier arm already shadows (plugs-backlog 2.02)

### DIFF
--- a/codex/plugs/zig/ZigEmitter.codex
+++ b/codex/plugs/zig/ZigEmitter.codex
@@ -2075,11 +2075,46 @@ Section: Match Emission
    in if zig-branches-guarded branches 0 then emit-zig-match-chain scrut branches ctx d mty
    else zig-pin-lit-arms branches 0 ("switch (" & emit-zig-expr scrut ctx (d + 1) & zig-match-deref ctx (zig-expr-type scrut) & ") { " & emit-zig-match-arms branches 0 ctx d ex mty tl & " }")
 
+ A zig `switch` prong refuses a value an earlier prong already names --
+ `error: duplicate switch value`, an error rather than a warning. Codex permits
+ the shape, because first-match-wins makes the later arm dead, and an
+ or-pattern expands on the wire into one branch per alternative, so a source
+ arm overlapping an earlier one arrives here as a second prong for the same
+ value. The duplicate cannot fire on any target, so it is DROPPED rather than
+ translated, which is the route the csharp plug took for CS8510.
+
+ Only a trivially-guarded earlier arm shadows. A guarded arm can decline at
+ runtime, which leaves the later prong reachable, and zig accepts that shape.
+
+ `zig-pat-switch-value` answers "" for every pattern that is not a bare prong
+ value -- a constructor carrying payloads binds names and is not a duplicate of
+ anything, and a var or wildcard is the else arm. Two empty answers are
+ therefore NOT equal for this purpose, which the emptiness test in
+ `zig-arm-shadowed` is there to say.
+
+  zig-pat-switch-value : IRPat -> Text
+  zig-pat-switch-value (pat) =
+   when pat
+    is IrLitPat (text) (ty) (sp) -> zig-lit-pat-text text ty
+    is IrCtorPat (name) (subs) (ty) (sp) ->
+     if list-length subs == 0 then "." & zig-sanitize name else ""
+    is otherwise -> ""
+
+  zig-arm-shadowed : List IRBranch, Integer, Text -> Boolean
+  zig-arm-shadowed (branches) (j) (sv) =
+   if sv == "" then False
+   else if j <= 0 then False
+   else let b = list-at branches (j - 1)
+   in if (zig-guard-trivial (b.guard)) & (zig-pat-switch-value (b.pattern) == sv) then True
+      else zig-arm-shadowed branches (j - 1) sv
+
   emit-zig-match-arms : List IRBranch, Integer, ZigCtx, Integer, Boolean, CodexType, ZigTail -> Text
   emit-zig-match-arms (branches) (i) (ctx) (d) (ex) (mty) (tl) =
    if i == list-length branches then ""
    else let b = list-at branches i
-   in emit-zig-match-arm (b.pattern) (b.body) (zig-expect ctx mty) d ex mty tl
+   in if zig-arm-shadowed branches i (zig-pat-switch-value (b.pattern))
+      then emit-zig-match-arms branches (i + 1) ctx d ex mty tl
+   else emit-zig-match-arm (b.pattern) (b.body) (zig-expect ctx mty) d ex mty tl
       & emit-zig-match-arms branches (i + 1) ctx d ex mty tl
 
  Constructor arms bind payloads: one field binds by name directly; a

--- a/codex/test/ops/match-shadowed-arm.codex
+++ b/codex/test/ops/match-shadowed-arm.codex
@@ -1,0 +1,51 @@
+Chapter: MatchShadowedArm
+
+  cites Foreword chapter Console
+
+ A `when` whose later arm names a value an earlier arm already named. Codex
+ permits it -- first-match-wins makes the later arm dead -- and every lane must
+ accept it, so it is a program about the PLUGS rather than about the compiler.
+
+ It is here because the shape is not reachable from ordinary source by
+ accident: an or-pattern expands on the wire into one branch per alternative,
+ so an arm overlapping an earlier one arrives at a plug as a second prong for
+ the same value. Backends whose switch refuses that -- zig's
+ `duplicate switch value`, C#'s CS8510 -- must drop the dead arm rather than
+ translate it.
+
+ THE DEAD ARMS ANSWER DIFFERENTLY FROM THE LIVE ONES, deliberately. If a
+ backend emitted the later arm instead of the earlier, or dropped the wrong
+ one, `one` would come back `SHADOW-INT` and `Leaf` would come back
+ `SHADOW-CTOR`. An arm carrying the same answer as the one it duplicates would
+ pass either way and prove nothing.
+
+Section: Types
+
+  Shape =
+    | Leaf
+    | Fork
+
+Section: Checks
+
+  classify : Integer -> Text
+  classify (n) = when n
+   is 1 -> "one"
+   is 2 -> "two"
+   is 1 -> "SHADOW-INT"
+   is otherwise -> "other"
+
+  name-of : Shape -> Text
+  name-of (s) = when s
+   is Leaf -> "leaf"
+   is Fork -> "fork"
+   is Leaf -> "SHADOW-CTOR"
+
+Section: Report
+
+  opening : [Console] Nothing = act
+    print-line (classify 1)
+    print-line (classify 2)
+    print-line (classify 3)
+    print-line (name-of Leaf)
+    print-line (name-of Fork)
+  end

--- a/codex/test/ops/match-shadowed-arm.expected
+++ b/codex/test/ops/match-shadowed-arm.expected
@@ -1,0 +1,5 @@
+one
+two
+other
+leaf
+fork


### PR DESCRIPTION
Claude here, working with Steve Howell on the zig phase-oracle ladder.

`codex/plugs/plugs-backlog.md` row **2.02** — "the zig plug REFUSES a redundant match arm that the compiler now emits combined, so it refuses legal Codex". This is the zig half of the route the csharp plug already took for CS8510 at 20352. Ladder tag `dup-arms-u53`.

## The shape, and why it is not exotic

A zig `switch` prong refuses a value an earlier prong already names — `error: duplicate switch value`, an error and not a warning. Codex permits the shape, because first-match-wins makes the later arm dead.

The reason this is worth a fix rather than a note is that the shape is **not something a person has to write on purpose**. An or-pattern expands on the wire into one branch per alternative, so a source arm that overlaps an earlier one arrives at the plug as a second prong for the same value. The author never sees a duplicate; the plug does.

## What the gate is

`zig-arm-shadowed branches i sv` drops arm `i` only when some earlier arm has the same non-empty switch value **and** is trivially guarded. Both halves matter:

- **Trivially guarded.** A guarded earlier arm can decline at runtime, which leaves the later prong reachable — and zig accepts that shape, so dropping it would change behaviour rather than preserve it.
- **Non-empty.** `zig-pat-switch-value` answers `""` for every pattern that is not a bare prong value: a constructor carrying payloads binds names and duplicates nothing, and a var or wildcard is the else arm. Two empty answers are therefore deliberately **not** equal to each other, which is what the `sv == ""` test at the top of `zig-arm-shadowed` is there to say. Without it every payload-carrying arm after the first would vanish.

`zig-branches-guarded` and `zig-pin-lit-arms` still see the whole branch list, so the guard-chain path (`emit-zig-match-chain`) is untouched — nothing is dropped from a match that does not become a `switch`.

## The test, and what would falsify it

`codex/test/ops/match-shadowed-arm` is new. It covers both shapes that can duplicate — an integer literal and a nullary constructor — and it is a program about the **plugs**, not about the compiler; every lane should accept it.

**The dead arms answer differently from the arms they shadow, deliberately.** `classify 1` has a live `-> "one"` and a dead `-> "SHADOW-INT"`; `name-of Leaf` has a live `-> "leaf"` and a dead `-> "SHADOW-CTOR"`. An emitter that dropped the *earlier* arm instead of the later, or that kept both and let zig pick, fails loudly instead of passing quietly. A test whose dead arm carried the same answer as the arm it duplicates would pass either way and prove nothing.

Against the plug as Update 53 ships it, the file fails to build with two `duplicate switch value` errors, one per shape. That is the falsifier this change had to clear, and it is baseline-free: it does not depend on any bank or any earlier measurement of ours.

## What settles it

**Bare metal, with a control.** `bare_expected.py` ran the new test under QEMU at seed `B066CEB5FE8FC9E8` and it matched its `.expected` on all five lines. The same pass re-ran `codex/test/ops/real-saturating-finite`, which this change cannot touch, and it matched on all nine — so the rig that produced the new answer is checked against one it could not have influenced.

**The fix demonstrably reached the build**, and the check that says so is the behavioural one above rather than a build fingerprint. We originally cited a natives-stamp difference here; that evidence was worthless and we have withdrawn it. Our stamp is a sha over the two native binaries, and each of them bakes its own build directory in as a literal string, so two builds of identical source in two different directories never stamp alike. It could not have caught the failure it was written for. `match-shadowed-arm` building on one arm and being refused on the other can, and did.

## What it found in your corpus

`circbuf-test` — an existing corpus program, none of ours — emitted this at plain Update 53:

```zig
.None => "\x20\x22\x49\x12\x10\x12\x0d", .None => "\x1c\x49\x12\x10\x12\x0d",
```

Two `.None` prongs in one switch: a real `duplicate switch value` in your corpus at Update 53, from an or-pattern, exactly the shape row 2.02 describes. With this change the switch carries three `.None` prongs across the file instead of four, the dead one is gone, the first-match-wins arm is the one kept, and the file is 37 bytes shorter.


## What we have not done

We do not run the non-zig plugs, and this touches none of them. `zig-pat-switch-value` renders literals through the existing `zig-lit-pat-text`, so it inherits whatever that does; we have not audited it for two distinct literals of one type rendering to the same text. Your battery is the arbiter for the new test.


