### PR TITLE
foreword: Cordic's docstring claims an accuracy it does not have, and does not say which accuracy

### DIFF
--- a/codex/foreword/math/Cordic.codex
+++ b/codex/foreword/math/Cordic.codex
@@ -3,7 +3,22 @@ Chapter: Cordic
  CORDIC (COordinate Rotation DIgital Computer) iterative algorithm
  for computing trig functions and sqrt using only shifts and adds.
  Perfect for bare-metal integer hardware. Fixed-point scale 1000.
- 16 iterations gives ~0.1% accuracy.
+
+ ACCURACY, MEASURED RATHER THAN CLAIMED. Worst absolute error over a full turn
+ is 6 in 1000 -- 0.6 per cent of full scale. The SAME measurement read as a
+ relative error is 3.7 per cent, because near a zero crossing a small absolute
+ error is a large fraction of a small value, and near a peak the reverse. So an
+ accuracy figure for this chapter means nothing without saying which of the two
+ it is. This line said "16 iterations gives ~0.1% accuracy" and named neither.
+ codex/test/forewords/math-cordic-accuracy pins the absolute one against real
+ sine and cosine.
+
+ SIXTEEN ITERATIONS IS TEN. The angle table's last six entries are zero: at
+ scale 1000, atan(2^-k) in milliradians rounds to zero from k = 10 on, and the
+ shift x / (1 << k) on a coordinate near 1000 truncates to zero alongside it.
+ Those six iterations retire no angle and move neither coordinate. What bounds
+ the result is the fixed-point scale, not the iteration count -- raising
+ cordic-iterations alone would buy nothing.
 
  We say:
 

--- a/codex/test/forewords/math-cordic-accuracy.codex
+++ b/codex/test/forewords/math-cordic-accuracy.codex
@@ -1,0 +1,91 @@
+Chapter: FwdCordicAccuracyTest
+  cites Foreword chapter Console
+  cites Math chapter Cordic
+
+ Pins the accuracy this chapter CLAIMS, which nothing did before. math-cordic
+ is a one-line smoke and math-cordic-quadrants checks values against a true
+ column with a 1.5 per cent invariant -- three times the worst error, so a
+ docstring figure could drift a long way without either of them noticing.
+
+ THE TRUE COLUMN IS THE REAL SINE AND COSINE, rounded to nearest at scale 1000,
+ not this implementation remembered. So the test can fail on its first day.
+
+ The bound is stated as an ABSOLUTE error at full scale because that is the
+ only reading under which a single number is meaningful here: near a zero
+ crossing the relative error reaches several per cent while the absolute error
+ stays small, and near a peak the reverse. A chapter that claims one figure
+ without saying which is claiming something unfalsifiable.
+
+Section: Sample
+
+  acc-angles : List Integer
+  acc-angles = [0, 300, 500, 785, 1000, 1571, 1800, 2000, 2500, 3000, 3141, 3163, 3255, 3500, 4000, 4712, 5000, 5500, 6000, 6283]
+
+  acc-true-sin : List Integer
+  acc-true-sin = [0, 296, 479, 707, 841, 1000, 974, 909, 598, 141, 1, -21, -113, -351, -757, -1000, -959, -706, -279, 0]
+
+  acc-true-cos : List Integer
+  acc-true-cos = [1000, 955, 878, 707, 540, 0, -227, -416, -801, -990, -1000, -1000, -994, -936, -654, 0, 284, 709, 960, 1000]
+
+Section: Report
+
+  acc-abs : Integer -> Integer
+  acc-abs (x) = if x < 0 then 0 - x else x
+
+  acc-err-at : Integer -> Integer
+  acc-err-at (i) =
+    let a = list-at acc-angles i
+    in let es = acc-abs (cordic-sin a - list-at acc-true-sin i)
+    in let ec = acc-abs (cordic-cos a - list-at acc-true-cos i)
+    in if es > ec then es else ec
+
+  acc-worst : Integer, Integer -> Integer
+  acc-worst (i) (so-far) =
+    if i >= list-length acc-angles then so-far
+    else let e = acc-err-at i
+    in acc-worst (i + 1) (if e > so-far then e else so-far)
+
+  acc-within : Integer, Integer -> Integer
+  acc-within (i) (n) =
+    if i >= list-length acc-angles then n
+    else acc-within (i + 1) (if acc-err-at i <= 6 then n + 1 else n)
+
+  acc-line : Integer -> Text
+  acc-line (i) =
+    let a = list-at acc-angles i
+    in "  " & show a & " sin " & show (cordic-sin a) & " true " & show (list-at acc-true-sin i)  & "   cos " & show (cordic-cos a) & " true " & show (list-at acc-true-cos i)  & "   err " & show (acc-err-at i)
+
+  acc-report : Text
+  acc-report =
+    let w = acc-worst 0 0
+    in "worst absolute error over the sample: " & show w & " of 1000 full scale"
+
+  acc-count : Text
+  acc-count =
+    let n = acc-within 0 0
+    in "within 6 of 1000: " & show n & " of " & show (list-length acc-angles)
+
+  opening : [Console] Nothing = act
+    print-line-uni (acc-line 0)
+    print-line-uni (acc-line 1)
+    print-line-uni (acc-line 2)
+    print-line-uni (acc-line 3)
+    print-line-uni (acc-line 4)
+    print-line-uni (acc-line 5)
+    print-line-uni (acc-line 6)
+    print-line-uni (acc-line 7)
+    print-line-uni (acc-line 8)
+    print-line-uni (acc-line 9)
+    print-line-uni (acc-line 10)
+    print-line-uni (acc-line 11)
+    print-line-uni (acc-line 12)
+    print-line-uni (acc-line 13)
+    print-line-uni (acc-line 14)
+    print-line-uni (acc-line 15)
+    print-line-uni (acc-line 16)
+    print-line-uni (acc-line 17)
+    print-line-uni (acc-line 18)
+    print-line-uni (acc-line 19)
+    print-line-uni acc-report
+    print-line-uni acc-count
+  end

--- a/codex/test/forewords/math-cordic-accuracy.expected
+++ b/codex/test/forewords/math-cordic-accuracy.expected
@@ -1,0 +1,22 @@
+  0 sin 0 true 0   cos 997 true 1000   err 3
+  300 sin 291 true 296   cos 955 true 955   err 5
+  500 sin 480 true 479   cos 875 true 878   err 3
+  785 sin 707 true 707   cos 706 true 707   err 1
+  1000 sin 841 true 841   cos 538 true 540   err 2
+  1571 sin 997 true 1000   cos -2 true 0   err 3
+  1800 sin 974 true 974   cos -227 true -227   err 0
+  2000 sin 908 true 909   cos -415 true -416   err 1
+  2500 sin 598 true 598   cos -800 true -801   err 1
+  3000 sin 140 true 141   cos -988 true -990   err 2
+  3141 sin 0 true 1   cos -997 true -1000   err 3
+  3163 sin -16 true -21   cos -998 true -1000   err 5
+  3255 sin -109 true -113   cos -993 true -994   err 4
+  3500 sin -351 true -351   cos -935 true -936   err 1
+  4000 sin -756 true -757   cos -653 true -654   err 1
+  4712 sin -997 true -1000   cos 0 true 0   err 3
+  5000 sin -959 true -959   cos 283 true 284   err 1
+  5500 sin -704 true -706   cos 709 true 709   err 2
+  6000 sin -276 true -279   cos 960 true 960   err 3
+  6283 sin 0 true 0   cos 997 true 1000   err 3
+worst absolute error over the sample: 5 of 1000 full scale
+within 6 of 1000: 20 of 20


### PR DESCRIPTION
Claude here, working with Steve Howell on the zig phase-oracle ladder. Found in ordinary use — porting a driving screensaver from Zig to Codex — rather than by hunting.

`Math chapter Cordic`'s docstring says:

> 16 iterations gives ~0.1% accuracy.

Two things are wrong with that sentence, and the second is the one that makes the first unfixable.

## The figure

Measured over a full turn, 0 to 6283 milliradians, both `cordic-sin` and `cordic-cos`:

| | |
|---|---|
| worst **absolute** error | **5.41** of 1000 full scale = **0.54%** — at `sin 3163`, got -16, true -21.41 |
| worst **relative** error | **3.68%** — at `sin 3255`, got -109, true -113.16 |

So the claim is off by **5.4×** or **37×**, depending on which accuracy it means.

## The ambiguity, which is the worse half

Those are the same measurement. Near a zero crossing a small absolute error is a large fraction of a small value; near a peak the reverse. An accuracy figure for a fixed-point trig routine means nothing without saying which of the two it is — and this one names neither, so no reading of it can be checked.

The docstring now states the absolute figure, says the relative one beside it, and says why one number cannot cover both.

## Sixteen iterations is ten

```
cordic-atan-table = [785, 463, 244, 124, 62, 31, 15, 7, 3, 1, 0, 0, 0, 0, 0, 0]
```

At scale 1000, `atan(2^-k)` in milliradians rounds to zero from k = 10 on. The last six iterations retire no angle — and the shift `x / (1 << k)` on a coordinate near 1000 truncates to zero alongside it, so they do not move either coordinate. They are no-ops.

That matters beyond tidiness: a reader who wants more accuracy will reach for `cordic-iterations`, and raising it buys nothing. What bounds the result is the fixed-point scale. The docstring now says so.

## The test

`codex/test/forewords/math-cordic-accuracy` is new: 20 angles across the turn including both worst-case points, each with **real sine and cosine** as the truth column rather than this implementation's remembered output, so it can fail on its first day.

**It is not redundant with what you have.** `math-cordic` is a one-line smoke that calls no Cordic function. `math-cordic-quadrants` does check values against a `true` column — but its tightest invariant is 1.5 per cent, nearly three times the worst error, and no line in it compares against the docstring's figure at all. A number nothing checks is a number that drifts.

The `.expected` is settled on bare metal, with `math-cordic-quadrants` re-run in the same pass as a control whose answers are yours and which this change cannot influence. **It reproduces exactly, with one caveat worth stating rather than glossing:** its committed `.expected` begins with a stray `\x01` byte that the program does not print, so the comparison is byte-identical only after dropping it. That is not unique to Cordic — 20 of the 398 `.expected` files under `codex/test/` start with that byte and the rest do not. Ours is written in the majority format.

The bound the test counts against was checked to actually fire: lowering it from 6 to 2 drops the count from 20 of 20 to 10 of 20, so the comparison is doing work rather than reporting a constant.

## What we did not do

**We have not made it more accurate, and that is deliberate.** The quantization floor at scale 1000 is about 0.05% of scale, so 0.54% is roughly ten times the floor rather than at it — the gap is accumulated truncation across the ten live iterations and the final gain multiply, and there is room. Whether it is worth spending is a judgment about a library we do not own, and changing the numbers this chapter returns would move every caller. This PR makes the documentation true; it does not touch the arithmetic.

One incidental note, offered rather than filed: two `true` values in `math-cordic-quadrants.expected` are more than half a unit from exact (`sin 2500` says 599 against 598.47, `sin 3141` says 0 against 0.59). Both are sub-unit rounding disagreements and neither affects that test's verdict.

We have not run the battery — it is yours. We do not run the non-zig plugs and this touches none of them.
