### PR TITLE
plugs: four silent wrong answers in the wasm plug, and the emission ceiling in both (safari port batch)

### DIFF
--- a/codex/plugs/wasm/WasmEmitter.codex
+++ b/codex/plugs/wasm/WasmEmitter.codex
@@ -202,9 +202,13 @@ Section: String Table
 
  A BRANCH'S GUARD IS PART OF THE BRANCH, and reading only the body made this
  walker answer a question about a program it had not finished looking at.
- `emit-wat-match-arm` emits the guard -- `emit-wat-guard-test` at :1620, :1623,
- :1627, :1632 and :1640 -- so a text literal that appears ONLY in a guard was
- emitted as a lookup into a table it was never added to, and `strtab-lookup`
+ The guard is emitted at TEN sites in two independent walkers, not five in one:
+ `emit-wat-match-arm` and `emit-wat-ctor-pat` reach `emit-wat-guard-test` five
+ times, and `emit-wat-branches-tco` five more. (The five line numbers this
+ comment used to give were a stale copy of the TCO walker's, and named the wrong
+ walker besides -- grep for the call, which is what a reader has to do anyway
+ once anything above it moves.) So a text literal that appears ONLY in a guard
+ was emitted as a lookup into a table it was never added to, and `strtab-lookup`
  answers 0 for a miss. Address zero, silently, on a module that assembles and
  runs. `probe/plug/guardstr.codex` in safari-codex is the case: the zig plug
  prints `yes` then `no`, and this one printed `no` twice.
@@ -214,6 +218,17 @@ Section: String Table
  discard something". The wasm plug never got that pass; it has the hole in both
  walkers. An unguarded branch carries a True literal as its guard, so walking
  it costs nothing on the common shape and changes no output that has no guard.
+
+ WHAT THIS FIX DID NOT SWEEP, said plainly because the first version of this
+ comment implied it had. The walkers still do not visit `b.pattern`, so a TEXT
+ LITERAL PATTERN -- `when t is "sin" -> ...` -- splices its spelling into
+ `(i64.const sin)` and wat2wasm refuses the module by name. That is a supported
+ feature with tests under `codex/test`, and closing it needs three things, not
+ one: the literal in the table, a `strtab-lookup` at the emission site, and
+ `$text_eq` instead of `i64.eq`. And the byte-identity of safari-codex's
+ seventeen checks is NOT evidence for any of this: there are no guarded match
+ arms in that port at all, so identical output was guaranteed by construction
+ before the fix was written.
 
   collect-strings-branches-loop : List IRBranch, List StringEntry, Integer -> List StringEntry
   collect-strings-branches-loop (bs) (acc) (i) =

--- a/codex/plugs/wasm/WasmEmitter.codex
+++ b/codex/plugs/wasm/WasmEmitter.codex
@@ -490,8 +490,52 @@ Section: Emitter Context
    arities : List ArityEntry,
    strings : List StringEntry,
    type-defs : List ATypeDef,
-   bound : List Text
+   bound : List Text,
+   scrut-depth : Integer
   }
+
+ THE SCRUTINEE LOCAL IS PER GUARD-NESTING DEPTH, and that is a correctness
+ rule rather than hygiene. `emit-wat-match` parks the scrutinee in a local and
+ the else-chain re-reads it for every branch below; a guard is emitted INSIDE
+ that chain's condition, so a `when` in a guard that shared the local would
+ overwrite the value the branches below still need. Measured before the fix:
+ `probe/plug/guardnest.codex` answered 720575940396056776 where the zig plug
+ answered 205, assembling cleanly on the way. A match in a branch BODY is safe
+ and keeps the same local -- once a body is selected the else-chain is dead --
+ so only guards deepen.
+
+ The names are unary (`_s`, `_ss`, `_sss`) so that the collector can shift one
+ level with no arithmetic and no parsing: walk a guard with a FRESH
+ accumulator, shift every scrutinee name it produced by one, merge. That is
+ why there is no depth parameter threaded through `collect-locals-expr` and no
+ second walker to keep in step with this one -- the shift composes, so a match
+ two guards deep is shifted twice by the same rule. A walker mirrored from
+ another walker is what put the last three defects here.
+
+  wat-scrut-name : Integer -> Text
+  wat-scrut-name (d) =
+   if d <= 0 then "_s" else wat-scrut-name (d - 1) & "s"
+
+  wat-scrut : WasmCtx -> Text
+  wat-scrut (ctx) = "$" & wat-scrut-name (ctx.scrut-depth)
+
+  wat-is-scrut : Text -> Boolean
+  wat-is-scrut (n) =
+   text-length n >= 2 & n == wat-scrut-name (text-length n - 2)
+
+  wat-shift-scrut-name : Text -> Text
+  wat-shift-scrut-name (n) =
+   if wat-is-scrut n then wat-scrut-name (text-length n - 1) else n
+
+  wat-shift-scrut : List Text, Integer, List Text -> List Text
+  wat-shift-scrut (xs) (i) (acc) =
+   if i >= list-length xs then acc
+   else wat-shift-scrut xs (i + 1) (list-push acc (wat-shift-scrut-name (list-at xs i)))
+
+  locals-merge : List Text, List Text, Integer -> List Text
+  locals-merge (acc) (xs) (i) =
+   if i >= list-length xs then acc
+   else locals-merge (locals-add acc (list-at xs i)) xs (i + 1)
 
 Section: Local Collection
 
@@ -566,7 +610,7 @@ Section: Local Collection
    if i >= list-length bs then acc
    else let b = list-at bs i
    in let acc1 = collect-locals-pat (b.pattern) acc
-   in let acc2 = collect-locals-expr (b.guard) acc1
+   in let acc2 = locals-merge acc1 (wat-shift-scrut (collect-locals-expr (b.guard) []) 0 []) 0
    in let acc3 = collect-locals-expr (b.body) acc2
    in collect-locals-branches-loop bs acc3 (i + 1)
 
@@ -1098,7 +1142,7 @@ Section: Expression Emission
   emit-wat-match : WasmCtx, IRExpr, List IRBranch, Integer -> Text
   emit-wat-match (ctx) (scrut) (branches) (depth) =
    if list-length branches == 0 then "(unreachable)"
-   else "(local.set $_s " & emit-wat-expr ctx scrut & ") " & emit-wat-match-body ctx branches 0 depth
+   else "(local.set " & wat-scrut ctx & " " & emit-wat-expr ctx scrut & ") " & emit-wat-match-body ctx branches 0 depth
 
   emit-wat-match-body : WasmCtx, List IRBranch, Integer, Integer -> Text
   emit-wat-match-body (ctx) (branches) (i) (depth) =
@@ -1113,19 +1157,20 @@ Section: Expression Emission
     is otherwise -> False
 
   emit-wat-guard-test : WasmCtx, IRExpr -> Text
-  emit-wat-guard-test (ctx) (guard) = "(i32.wrap_i64 " & emit-wat-expr ctx guard & ")"
+  emit-wat-guard-test (ctx) (guard) =
+   "(i32.wrap_i64 " & emit-wat-expr (__record-set ctx "scrut-depth" (ctx.scrut-depth + 1)) guard & ")"
 
   emit-wat-match-arm : WasmCtx, IRPat, IRExpr, IRExpr, List IRBranch, Integer, Integer -> Text
   emit-wat-match-arm (ctx) (pat) (guard) (body) (branches) (i) (depth) =
    when pat
     is IrLitPat (text) (ty) (sp) ->
-     let lit-test = "(i64.eq (local.get $_s) (i64.const " & text & "))"
+     let lit-test = "(i64.eq (local.get " & wat-scrut ctx & ") (i64.const " & text & "))"
      in let cond = if wat-guard-trivial guard then lit-test
         else "(i32.and " & lit-test & " " & emit-wat-guard-test ctx guard & ")"
      in "(if (result i64) " & cond & " (then " & emit-wat-expr ctx body & ") (else " & emit-wat-match-body ctx branches (i + 1) depth & "))"
     is IrCtorPat (name) (subs) (ty) (sp) -> emit-wat-ctor-pat ctx name subs guard body branches i depth
     is IrVarPat (name) (ty) (sp) ->
-     let bind = "(local.set $" & wat-sanitize name & " (local.get $_s)) "
+     let bind = "(local.set $" & wat-sanitize name & " (local.get " & wat-scrut ctx & ")) "
      in if wat-guard-trivial guard then bind & emit-wat-expr ctx body
         else bind & "(if (result i64) " & emit-wat-guard-test ctx guard & " (then " & emit-wat-expr ctx body & ") (else " & emit-wat-match-body ctx branches (i + 1) depth & "))"
     is IrWildPat (sp) ->
@@ -1146,7 +1191,7 @@ Section: Expression Emission
    in if (i == list-length branches - 1) & wat-guard-trivial guard then
     bind-subs & emit-wat-expr ctx body
    else
-    let tag-test = "(i64.eq (i64.load (i32.wrap_i64 (local.get $_s))) (i64.const " & integer-to-text tag & "))"
+    let tag-test = "(i64.eq (i64.load (i32.wrap_i64 (local.get " & wat-scrut ctx & "))) (i64.const " & integer-to-text tag & "))"
     in let cond = if wat-guard-trivial guard then tag-test
        else "(if (result i32) " & tag-test & " (then " & bind-subs & emit-wat-guard-test ctx guard & ") (else (i32.const 0)))"
     in "(if (result i64) " & cond & " (then " & bind-subs & emit-wat-expr ctx body & ") (else " & emit-wat-match-body ctx branches (i + 1) depth & "))"
@@ -1157,7 +1202,7 @@ Section: Expression Emission
    else let off = 8 + i * 8
    in let sub = list-at subs i
    in (when sub
-    is IrVarPat (name) (ty) (sp) -> "(local.set $" & wat-sanitize name & " (i64.load (i32.add (i32.wrap_i64 (local.get $_s)) (i32.const " & integer-to-text off & ")))) "
+    is IrVarPat (name) (ty) (sp) -> "(local.set $" & wat-sanitize name & " (i64.load (i32.add (i32.wrap_i64 (local.get " & wat-scrut ctx & ")) (i32.const " & integer-to-text off & ")))) "
     is IrWildPat (sp) -> ""
     is IrVecPat (pats) (ty) (sp) -> ""
     is otherwise -> "") & emit-wat-bind-ctor-subs ctx subs (i + 1)
@@ -1625,7 +1670,7 @@ Section: Tail Call Optimization
 
   emit-wat-match-tco : WasmCtx, Text, List IRParam, IRExpr, List IRBranch, Integer -> Text
   emit-wat-match-tco (ctx) (fname) (params) (scrut) (branches) (depth) =
-   "(local.set $_s " & emit-wat-expr-at ctx scrut (depth + 1) & ") " & emit-wat-branches-tco ctx fname params branches 0 depth
+   "(local.set " & wat-scrut ctx & " " & emit-wat-expr-at ctx scrut (depth + 1) & ") " & emit-wat-branches-tco ctx fname params branches 0 depth
 
   emit-wat-branches-tco : WasmCtx, Text, List IRParam, List IRBranch, Integer, Integer -> Text
   emit-wat-branches-tco (ctx) (fname) (params) (bs) (i) (depth) =
@@ -1643,12 +1688,12 @@ Section: Tail Call Optimization
      if guarded == False then body
      else "(if (result i64) " & emit-wat-guard-test ctx (b.guard) & " (then " & body & ") (else " & rest & "))"
     is IrVarPat (name) (ty) (sp) ->
-     let bind = "(local.set $" & wat-sanitize name & " (local.get $_s)) "
+     let bind = "(local.set $" & wat-sanitize name & " (local.get " & wat-scrut ctx & ")) "
      in if guarded == False then bind & body
         else bind & "(if (result i64) " & emit-wat-guard-test ctx (b.guard) & " (then " & body & ") (else " & rest & "))"
     is IrLitPat (text) (ty) (sp) ->
      if is-last then body
-     else let lit-test = "(i64.eq (local.get $_s) (i64.const " & text & "))"
+     else let lit-test = "(i64.eq (local.get " & wat-scrut ctx & ") (i64.const " & text & "))"
      in let cond = if guarded == False then lit-test
         else "(i32.and " & lit-test & " " & emit-wat-guard-test ctx (b.guard) & ")"
      in "(if (result i64) " & cond & " (then " & body & ") (else " & rest & "))"
@@ -1656,7 +1701,7 @@ Section: Tail Call Optimization
      let tag = find-ctor-in-typedefs (ctx.type-defs) name 0
      in let bind = emit-wat-bind-ctor-subs ctx subs 0
      in if is-last then bind & body
-     else let tag-test = "(i64.eq (i64.load (i32.wrap_i64 (local.get $_s))) (i64.const " & integer-to-text tag & "))"
+     else let tag-test = "(i64.eq (i64.load (i32.wrap_i64 (local.get " & wat-scrut ctx & "))) (i64.const " & integer-to-text tag & "))"
      in let cond = if guarded == False then tag-test
         else "(if (result i32) " & tag-test & " (then " & bind & emit-wat-guard-test ctx (b.guard) & ") (else (i32.const 0)))"
      in "(if (result i64) " & cond & " (then " & bind & body & ") (else " & rest & "))"
@@ -3027,8 +3072,25 @@ Section: Chapter Emission
  without defining it halts with CDX3002 and a chapter that defines it emits a
  module the assembler refuses. `needs-blit` is therefore True only for programs
  that cannot assemble anyway, which is exactly the shape `$on_key_import` is in
- for a different reason. Both are recorded as a finding; the query below is
- correct and cheap, and it is not what is wrong here.
+ for a different reason. Both are recorded as a finding.
+
+ AND THE QUERY WAS NOT ASKING ABOUT CALL SITES. It asked whether the name
+ OCCURS: the `IrName` arm answered `nm == n` for any mention, so an ordinary
+ binding spelled `blit-framebuf` -- a local, a parameter -- set the flag and the
+ module carried an `env` import nothing can satisfy. That module ASSEMBLES and
+ dies at instantiation, `unknown import: env::blit_framebuf`, which is worse
+ than the text scan it replaced rather than better. Measured in
+ `probe/plug/blitname.codex`. A call is now a name in the HEAD of an apply
+ spine, which is what the prose above always claimed it was; a bare mention is
+ not a call. Two commits in a row argued from a model of a walker instead of
+ from the walker, and this is the second one.
+
+  wat-apply-head-is : IRExpr, Text -> Boolean
+  wat-apply-head-is (e) (n) =
+   when e
+    is IrName (nm) (ty) (sp) -> nm == n
+    is IrApply (f) (a) (ty) (sp) -> wat-apply-head-is f n
+    is otherwise -> False
 
   wat-expr-calls-name : IRExpr, Text -> Boolean
   wat-expr-calls-name (e) (n) =
@@ -3038,12 +3100,12 @@ Section: Chapter Emission
     is IrTextLit (s) (sp) -> False
     is IrBoolLit (bv) (sp) -> False
     is IrCharLit (cv) (sp) -> False
-    is IrName (nm) (ty) (sp) -> nm == n
+    is IrName (nm) (ty) (sp) -> False
     is IrBinary (op) (l) (r) (ty) (sp) -> wat-expr-calls-name l n | wat-expr-calls-name r n
     is IrNegate (operand) (nty) (sp) -> wat-expr-calls-name operand n
     is IrIf (c) (t) (el) (ty) (sp) -> wat-expr-calls-name c n | wat-expr-calls-name t n | wat-expr-calls-name el n
     is IrLet (name) (ty) (val) (body) (sp) -> wat-expr-calls-name val n | wat-expr-calls-name body n
-    is IrApply (f) (a) (ty) (sp) -> wat-expr-calls-name f n | wat-expr-calls-name a n
+    is IrApply (f) (a) (ty) (sp) -> wat-apply-head-is f n | wat-expr-calls-name f n | wat-expr-calls-name a n
     is IrLambda (params) (body) (ty) (sp) -> wat-expr-calls-name body n
     is IrList (elems) (ty) (sp) -> wat-list-calls-name elems n 0
     is IrMatch (scrut) (branches) (ty) (sp) -> wat-expr-calls-name scrut n | wat-branches-call-name branches n 0
@@ -3143,7 +3205,7 @@ Section: Chapter Emission
    in let fnarity-base = cce-tab-base + cce-tables-bytes
    in let max-arity = wat-fn-type-ceiling arities
    in let heap-start = fnarity-base + list-length arities
-   in let ctx = WasmCtx { arities = arities, strings = strings, type-defs = type-defs, bound = [] }
+   in let ctx = WasmCtx { arities = arities, strings = strings, type-defs = type-defs, bound = [], scrut-depth = 0 }
    in let runtime = wat-runtime-funcs cce-tab-base cce-t2-base cce-out-base fnarity-base max-arity cce-rev-base cce-in-base
    in let data-text = emit-data-sections strings 0
    in let types-text = emit-wat-type-defs type-defs 0 & wat-eq-funcs type-defs 0

--- a/codex/plugs/wasm/WasmEmitter.codex
+++ b/codex/plugs/wasm/WasmEmitter.codex
@@ -200,11 +200,26 @@ Section: String Table
   collect-strings-branches (bs) (acc) =
    collect-strings-branches-loop bs acc 0
 
+ A BRANCH'S GUARD IS PART OF THE BRANCH, and reading only the body made this
+ walker answer a question about a program it had not finished looking at.
+ `emit-wat-match-arm` emits the guard -- `emit-wat-guard-test` at :1620, :1623,
+ :1627, :1632 and :1640 -- so a text literal that appears ONLY in a guard was
+ emitted as a lookup into a table it was never added to, and `strtab-lookup`
+ answers 0 for a miss. Address zero, silently, on a module that assembles and
+ runs. `probe/plug/guardstr.codex` in safari-codex is the case: the zig plug
+ prints `yes` then `no`, and this one printed `no` twice.
+
+ ZigEmitter fixed the same class in `zig-occurs-branches` and its note is the
+ one to read -- "every caller of this uses the answer to decide whether to
+ discard something". The wasm plug never got that pass; it has the hole in both
+ walkers. An unguarded branch carries a True literal as its guard, so walking
+ it costs nothing on the common shape and changes no output that has no guard.
+
   collect-strings-branches-loop : List IRBranch, List StringEntry, Integer -> List StringEntry
   collect-strings-branches-loop (bs) (acc) (i) =
    if i >= list-length bs then acc
    else let b = list-at bs i
-   in collect-strings-branches-loop bs (collect-strings-expr (b.body) acc) (i + 1)
+   in collect-strings-branches-loop bs (collect-strings-expr (b.body) (collect-strings-expr (b.guard) acc)) (i + 1)
 
   collect-strings-stmts : List IRActStmt, List StringEntry -> List StringEntry
   collect-strings-stmts (ss) (acc) =
@@ -541,13 +556,19 @@ Section: Local Collection
   collect-locals-branches (bs) (acc) =
    collect-locals-branches-loop bs acc 0
 
+ The same hole, one walker over. A `let` inside a guard yielded a local that
+ was used and never declared, which `wat2wasm` refuses by name -- so this half
+ fails loudly where the string table's half fails silently, and that is the only
+ reason it was the second one found rather than the first.
+
   collect-locals-branches-loop : List IRBranch, List Text, Integer -> List Text
   collect-locals-branches-loop (bs) (acc) (i) =
    if i >= list-length bs then acc
    else let b = list-at bs i
    in let acc1 = collect-locals-pat (b.pattern) acc
-   in let acc2 = collect-locals-expr (b.body) acc1
-   in collect-locals-branches-loop bs acc2 (i + 1)
+   in let acc2 = collect-locals-expr (b.guard) acc1
+   in let acc3 = collect-locals-expr (b.body) acc2
+   in collect-locals-branches-loop bs acc3 (i + 1)
 
   collect-locals-pat : IRPat, List Text -> List Text
   collect-locals-pat (p) (acc) =
@@ -3027,6 +3048,7 @@ Section: Chapter Emission
   wat-branches-call-name : List IRBranch, Text, Integer -> Boolean
   wat-branches-call-name (bs) (n) (i) =
    if i >= list-length bs then False
+   else if wat-expr-calls-name ((list-at bs i).guard) n then True
    else if wat-expr-calls-name ((list-at bs i).body) n then True
    else wat-branches-call-name bs n (i + 1)
 

--- a/codex/plugs/wasm/WasmEmitter.codex
+++ b/codex/plugs/wasm/WasmEmitter.codex
@@ -2931,26 +2931,104 @@ Section: Chapter Emission
  shape and the pattern is taken from it: mark the heap, emit ONE definition,
  print it, restore the mark. Only a scalar may cross the restore.
 
-  wasm-defs-mention : WasmCtx, List IRDef, Integer, Text -> Boolean
-  wasm-defs-mention (ctx) (defs) (i) (needle) =
-   if i >= list-length defs then False
-   else let h = __heap-save
-   in let hit = text-contains (emit-wat-def ctx (list-at defs i)) needle
-   in let restored = __heap-restore h
-   in if hit then True else wasm-defs-mention ctx defs (i + 1) needle
+ The header must be printed BEFORE the definitions and depends on whether any
+ of them calls an `env` import, which is why the old code materialised the whole
+ body first. The three FIXED pieces are scanned as text -- they are built
+ already and a needle cannot span the joins, because every piece is
+ newline-terminated and no emitter splits a token across one.
 
- The header must be printed BEFORE the definitions and depends on whether
- any of them calls an `env` import, which is why the old code materialised
- the whole body first. Scanning the pieces separately answers the same
- question without holding them: a needle cannot span the joins, because
- every piece is newline-terminated and no emitter splits a token across one.
+ THE DEFINITIONS ARE ASKED IN THE IR INSTEAD, and that is a fix rather than a
+ tidy-up. Until 2026-08-31 this scanned them by EMITTING EVERY DEFINITION IN
+ FULL and running `text-contains` over the result, twice, throwing both texts
+ away -- so a module cost three emissions of every definition and printed one.
+ Measured on a 95 KB unit: 766 MB of churn through the per-definition brackets,
+ 510 MB of it the two scans. It is also where a 696 KB unit DIED -- 41
+ definitions into the FIRST scan, so the panic named a phase whose entire output
+ is a boolean and the definitions it was asked to print were never reached.
 
-  wasm-mention-any : WasmCtx, List IRDef, Text, Text, Text, Text -> Boolean
-  wasm-mention-any (ctx) (defs) (runtime) (types-text) (entry) (needle) =
+ An import is needed when a definition CALLS the builtin, and the IR says so
+ with no allocation at all. The walk mirrors `collect-strings-expr` arm for arm,
+ which is the argument for its coverage: that shape already has to reach every
+ text literal in the program or the string table comes out short. Where the two
+ differ is a case the text scan got WRONG: a chapter that DEFINES `blit-framebuf`
+ emits `(func $blit_framebuf`, the old needle hit, and the module declared an
+ import and a function under one name -- which `wat2wasm` refuses. Asking about
+ call sites cannot do that.
+
+  wat-expr-calls-name : IRExpr, Text -> Boolean
+  wat-expr-calls-name (e) (n) =
+   when e
+    is IrIntLit (v) (sp) -> False
+    is IrNumLit (v) (sp) -> False
+    is IrTextLit (s) (sp) -> False
+    is IrBoolLit (bv) (sp) -> False
+    is IrCharLit (cv) (sp) -> False
+    is IrName (nm) (ty) (sp) -> nm == n
+    is IrBinary (op) (l) (r) (ty) (sp) -> wat-expr-calls-name l n | wat-expr-calls-name r n
+    is IrNegate (operand) (nty) (sp) -> wat-expr-calls-name operand n
+    is IrIf (c) (t) (el) (ty) (sp) -> wat-expr-calls-name c n | wat-expr-calls-name t n | wat-expr-calls-name el n
+    is IrLet (name) (ty) (val) (body) (sp) -> wat-expr-calls-name val n | wat-expr-calls-name body n
+    is IrApply (f) (a) (ty) (sp) -> wat-expr-calls-name f n | wat-expr-calls-name a n
+    is IrLambda (params) (body) (ty) (sp) -> wat-expr-calls-name body n
+    is IrList (elems) (ty) (sp) -> wat-list-calls-name elems n 0
+    is IrMatch (scrut) (branches) (ty) (sp) -> wat-expr-calls-name scrut n | wat-branches-call-name branches n 0
+    is IrAct (stmts) (ty) (sp) -> wat-stmts-call-name stmts n 0
+    is IrHandle (eff) (body) (clauses) (ty) (sp) -> wat-expr-calls-name body n
+    is IrWithTimeout (secs) (effs) (scopes) (body) (ty) (sp) -> wat-expr-calls-name body n
+    is IrRecord (name) (fields) (ty) (sp) -> wat-fields-call-name fields n 0
+    is IrFieldAccess (rec) (field) (ty) (sp) -> wat-expr-calls-name rec n
+    is IrFieldStore (rec) (field) (val) (ty) (sp) -> wat-expr-calls-name rec n | wat-expr-calls-name val n
+    is IrFork (body) (ty) (sp) -> wat-expr-calls-name body n
+    is IrAwait (task) (ty) (sp) -> wat-expr-calls-name task n
+    is IrTry (max) (body) (fb) (fail-stmts) (ty) (sp) -> wat-stmts-call-name body n 0 | wat-stmts-call-name fb n 0 | wat-stmts-call-name fail-stmts n 0
+    is IrError (msg) (ty) (sp) -> False
+
+  wat-list-calls-name : List IRExpr, Text, Integer -> Boolean
+  wat-list-calls-name (xs) (n) (i) =
+   if i >= list-length xs then False
+   else if wat-expr-calls-name (list-at xs i) n then True
+   else wat-list-calls-name xs n (i + 1)
+
+  wat-branches-call-name : List IRBranch, Text, Integer -> Boolean
+  wat-branches-call-name (bs) (n) (i) =
+   if i >= list-length bs then False
+   else if wat-expr-calls-name ((list-at bs i).body) n then True
+   else wat-branches-call-name bs n (i + 1)
+
+  wat-stmts-call-name : List IRActStmt, Text, Integer -> Boolean
+  wat-stmts-call-name (ss) (n) (i) =
+   if i >= list-length ss then False
+   else let hit = when (list-at ss i)
+    is IrDoBind (name) (ty) (val) (sp) -> wat-expr-calls-name val n
+    is IrDoExec (e) (sp) -> wat-expr-calls-name e n
+   in if hit then True else wat-stmts-call-name ss n (i + 1)
+
+  wat-fields-call-name : List IRFieldVal, Text, Integer -> Boolean
+  wat-fields-call-name (fs) (n) (i) =
+   if i >= list-length fs then False
+   else if wat-expr-calls-name ((list-at fs i).value) n then True
+   else wat-fields-call-name fs n (i + 1)
+
+ An empty builtin name answers False without walking, and it is not a sentinel
+ for "unused": `$on_key_import` HAS no producer -- no arm of this emitter emits
+ it -- so the scan that used to look for it walked every definition of every
+ chapter to say False, always. The flag and its import line are kept rather than
+ deleted because the hole is that `on-key` has no builtin arm, which is finding
+ 1's shape, and deleting the line it guards would hide it.
+
+  wat-defs-call-name : List IRDef, Text, Integer -> Boolean
+  wat-defs-call-name (defs) (n) (i) =
+   if n == "" then False
+   else if i >= list-length defs then False
+   else if wat-expr-calls-name ((list-at defs i).body) n then True
+   else wat-defs-call-name defs n (i + 1)
+
+  wasm-mention-any : List IRDef, Text, Text, Text, Text, Text -> Boolean
+  wasm-mention-any (defs) (runtime) (types-text) (entry) (needle) (builtin) =
    if text-contains runtime needle then True
    else if text-contains types-text needle then True
    else if text-contains entry needle then True
-   else wasm-defs-mention ctx defs 0 needle
+   else wat-defs-call-name defs builtin 0
 
   wasm-stream-defs : WasmCtx, List IRDef, Integer -> [Console] Nothing
   wasm-stream-defs (ctx) (defs) (i) =
@@ -2986,8 +3064,8 @@ Section: Chapter Emission
    in let data-text = emit-data-sections strings 0
    in let types-text = emit-wat-type-defs type-defs 0 & wat-eq-funcs type-defs 0
    in let entry = wat-emit-entry (m.defs)
-   in let needs-blit = wasm-mention-any ctx (m.defs) runtime types-text entry "$blit_framebuf"
-   in let needs-key = wasm-mention-any ctx (m.defs) runtime types-text entry "$on_key_import"
+   in let needs-blit = wasm-mention-any (m.defs) runtime types-text entry "$blit_framebuf" "blit-framebuf"
+   in let needs-key = wasm-mention-any (m.defs) runtime types-text entry "$on_key_import" ""
    in let header = wat-runtime-header heap-start needs-blit needs-key
    in act
     print-uni header

--- a/codex/plugs/wasm/WasmEmitter.codex
+++ b/codex/plugs/wasm/WasmEmitter.codex
@@ -757,13 +757,13 @@ Section: Expression Emission
    if depth >= 4096 then "(unreachable (; wasm plug: expression nested past 4096, no form ;))"
    else when e
     is IrIntLit (n) (sp) -> "(i64.const " & integer-to-text n & ")"
-    is IrNumLit (n) (sp) -> "(f64.reinterpret_i64 (i64.const " & integer-to-text n & "))"
+    is IrNumLit (n) (sp) -> "(i64.const " & integer-to-text n & ")"
     is IrTextLit (s) (sp) -> "(i64.extend_i32_u (i32.const " & integer-to-text (strtab-lookup (ctx.strings) s 0) & "))"
     is IrBoolLit (b) (sp) -> if b then "(i64.const 1)" else "(i64.const 0)"
     is IrCharLit (n) (sp) -> "(i64.const " & integer-to-text n & ")"
     is IrName (n) (ty) (sp) -> emit-wat-name ctx n
     is IrBinary (op) (l) (r) (ty) (sp) -> emit-wat-binary ctx op l r depth
-    is IrNegate (operand) (nty) (sp) -> "(i64.sub (i64.const 0) " & emit-wat-expr-at ctx operand (depth + 1) & ")"
+    is IrNegate (operand) (nty) (sp) -> if wat-is-real-type nty then "(i64.reinterpret_f64 (f64.neg (f64.reinterpret_i64 " & emit-wat-expr-at ctx operand (depth + 1) & ")))" else "(i64.sub (i64.const 0) " & emit-wat-expr-at ctx operand (depth + 1) & ")"
     is IrIf (c) (t) (el) (ty) (sp) -> "(if (result i64) (i32.wrap_i64 " & emit-wat-expr-at ctx c (depth + 1) & ") (then " & emit-wat-expr-at ctx t (depth + 1) & ") (else " & emit-wat-expr-at ctx el (depth + 1) & "))"
     is IrLet (name) (ty) (val) (body) (sp) -> "(local.set $" & wat-sanitize name & " " & emit-wat-expr-at ctx val (depth + 1) & ") " & emit-wat-expr-at ctx body (depth + 1)
     is IrApply (f) (a) (ty) (sp) -> emit-wat-apply ctx e
@@ -987,18 +987,25 @@ Section: Expression Emission
     is IrEq -> if wat-is-text-type (ir-expr-type l) then "(call $text_eq " & emit-wat-expr-at ctx l (depth + 1) & " " & emit-wat-expr-at ctx r (depth + 1) & ")"
               else let sn = wat-eq-sum-name (ctx.type-defs) (ir-expr-type l)
               in if text-length sn > 0 then "(call " & wat-eq-fn-prefix & wat-sanitize sn & " " & emit-wat-expr-at ctx l (depth + 1) & " " & emit-wat-expr-at ctx r (depth + 1) & ")"
+              else if wat-is-real-type (ir-expr-type l) then wat-real-cmp "f64.eq" (emit-wat-expr-at ctx l (depth + 1)) (emit-wat-expr-at ctx r (depth + 1))
               else "(i64.extend_i32_u (" & wat-bin-instr op & " " & emit-wat-expr-at ctx l (depth + 1) & " " & emit-wat-expr-at ctx r (depth + 1) & "))"
     is IrNotEq -> if wat-is-text-type (ir-expr-type l) then "(i64.extend_i32_u (i64.eqz (call $text_eq " & emit-wat-expr-at ctx l (depth + 1) & " " & emit-wat-expr-at ctx r (depth + 1) & ")))"
                  else let sn = wat-eq-sum-name (ctx.type-defs) (ir-expr-type l)
                  in if text-length sn > 0 then "(i64.extend_i32_u (i64.eqz (call " & wat-eq-fn-prefix & wat-sanitize sn & " " & emit-wat-expr-at ctx l (depth + 1) & " " & emit-wat-expr-at ctx r (depth + 1) & ")))"
+                 else if wat-is-real-type (ir-expr-type l) then wat-real-cmp "f64.ne" (emit-wat-expr-at ctx l (depth + 1)) (emit-wat-expr-at ctx r (depth + 1))
                  else "(i64.extend_i32_u (" & wat-bin-instr op & " " & emit-wat-expr-at ctx l (depth + 1) & " " & emit-wat-expr-at ctx r (depth + 1) & "))"
-    is IrLt | IrLtVec -> "(i64.extend_i32_u (" & wat-bin-instr op & " " & emit-wat-expr-at ctx l (depth + 1) & " " & emit-wat-expr-at ctx r (depth + 1) & "))"
-    is IrGt | IrGtVec -> "(i64.extend_i32_u (" & wat-bin-instr op & " " & emit-wat-expr-at ctx l (depth + 1) & " " & emit-wat-expr-at ctx r (depth + 1) & "))"
-    is IrLtEq | IrLtEqVec -> "(i64.extend_i32_u (" & wat-bin-instr op & " " & emit-wat-expr-at ctx l (depth + 1) & " " & emit-wat-expr-at ctx r (depth + 1) & "))"
-    is IrGtEq | IrGtEqVec -> "(i64.extend_i32_u (" & wat-bin-instr op & " " & emit-wat-expr-at ctx l (depth + 1) & " " & emit-wat-expr-at ctx r (depth + 1) & "))"
+    is IrLt | IrLtVec -> if wat-is-real-type (ir-expr-type l) then wat-real-cmp "f64.lt" (emit-wat-expr-at ctx l (depth + 1)) (emit-wat-expr-at ctx r (depth + 1))
+              else "(i64.extend_i32_u (" & wat-bin-instr op & " " & emit-wat-expr-at ctx l (depth + 1) & " " & emit-wat-expr-at ctx r (depth + 1) & "))"
+    is IrGt | IrGtVec -> if wat-is-real-type (ir-expr-type l) then wat-real-cmp "f64.gt" (emit-wat-expr-at ctx l (depth + 1)) (emit-wat-expr-at ctx r (depth + 1))
+              else "(i64.extend_i32_u (" & wat-bin-instr op & " " & emit-wat-expr-at ctx l (depth + 1) & " " & emit-wat-expr-at ctx r (depth + 1) & "))"
+    is IrLtEq | IrLtEqVec -> if wat-is-real-type (ir-expr-type l) then wat-real-cmp "f64.le" (emit-wat-expr-at ctx l (depth + 1)) (emit-wat-expr-at ctx r (depth + 1))
+              else "(i64.extend_i32_u (" & wat-bin-instr op & " " & emit-wat-expr-at ctx l (depth + 1) & " " & emit-wat-expr-at ctx r (depth + 1) & "))"
+    is IrGtEq | IrGtEqVec -> if wat-is-real-type (ir-expr-type l) then wat-real-cmp "f64.ge" (emit-wat-expr-at ctx l (depth + 1)) (emit-wat-expr-at ctx r (depth + 1))
+              else "(i64.extend_i32_u (" & wat-bin-instr op & " " & emit-wat-expr-at ctx l (depth + 1) & " " & emit-wat-expr-at ctx r (depth + 1) & "))"
     is IrApproxEq -> "(i64.extend_i32_u (" & wat-bin-instr op & " " & emit-wat-expr-at ctx l (depth + 1) & " " & emit-wat-expr-at ctx r (depth + 1) & "))"
     is IrApproxEqExact -> "(i64.extend_i32_u (" & wat-bin-instr op & " " & emit-wat-expr-at ctx l (depth + 1) & " " & emit-wat-expr-at ctx r (depth + 1) & "))"
-    is otherwise -> "(" & wat-bin-instr op & " " & emit-wat-expr-at ctx l (depth + 1) & " " & emit-wat-expr-at ctx r (depth + 1) & ")"
+    is otherwise -> if wat-is-real-op op then wat-real-bin (wat-bin-instr op) (emit-wat-expr-at ctx l (depth + 1)) (emit-wat-expr-at ctx r (depth + 1))
+                   else "(" & wat-bin-instr op & " " & emit-wat-expr-at ctx l (depth + 1) & " " & emit-wat-expr-at ctx r (depth + 1) & ")"
 
   wat-bin-instr : IRBinaryOp -> Text
   wat-bin-instr (op) =
@@ -1247,6 +1254,42 @@ Section: Apply Emission
    if i == list-length args then ""
    else emit-wat-expr ctx (list-at args i) & " " & emit-wat-apply-args ctx args (i + 1)
 
+ EVERY REAL ON THIS TARGET IS AN i64 HOLDING f64 BITS, and that is a decision
+ with a cost: the slot, the list element, the record field and the function
+ result are all i64, so an f64 has to be reinterpreted INTO an operation and the
+ result reinterpreted back OUT of it. Neither reinterpret is an instruction the
+ engine executes -- both are pure retypings of the same 64 bits -- so the cost is
+ in the text and not in the module.
+
+ The three predicates below are what decide where those wrappers go. `RealTy`
+ carries a width and a mode and both are DISCARDED here, exactly as the zig plug
+ discards them (PLUG_WORK.md): an f32 real is computed as f64 and a trapping real
+ does not trap. That is a house-wide position and not this chapter's to take.
+
+  wat-is-real-type : CodexType -> Boolean
+  wat-is-real-type (ty) =
+   when ty
+    is RealTy (w) (m) -> True
+    is EffectfulTy (effs) (scopes) (ret) -> wat-is-real-type ret
+    is otherwise -> False
+
+  wat-is-real-op : IRBinaryOp -> Boolean
+  wat-is-real-op (op) =
+   when op
+    is IrAddNum | IrAddRealApprox | IrAddRealTrapping | IrAddRealSaturating -> True
+    is IrSubNum | IrSubRealApprox | IrSubRealTrapping | IrSubRealSaturating -> True
+    is IrMulNum | IrMulRealApprox | IrMulRealTrapping | IrMulRealSaturating -> True
+    is IrDivNum | IrDivRealApprox | IrDivRealTrapping | IrDivRealSaturating -> True
+    is otherwise -> False
+
+  wat-real-bin : Text, Text, Text -> Text
+  wat-real-bin (instr) (la) (lb) =
+   "(i64.reinterpret_f64 (" & instr & " (f64.reinterpret_i64 " & la & ") (f64.reinterpret_i64 " & lb & ")))"
+
+  wat-real-cmp : Text, Text, Text -> Text
+  wat-real-cmp (instr) (la) (lb) =
+   "(i64.extend_i32_u (" & instr & " (f64.reinterpret_i64 " & la & ") (f64.reinterpret_i64 " & lb & ")))"
+
   wat-is-text-type : CodexType -> Boolean
   wat-is-text-type (ty) =
    when ty
@@ -1394,6 +1437,9 @@ Section: Apply Emission
    else if n == "code-to-char" then emit-wat-expr ctx (list-at args 0)
    else if n == "negate" then "(i64.sub (i64.const 0) " & emit-wat-expr ctx (list-at args 0) & ")"
    else if n == "int-mod" then "(call $codex_mod " & emit-wat-expr ctx (list-at args 0) & " " & emit-wat-expr ctx (list-at args 1) & ")"
+   else if n == "real-to-bits" | n == "bits-to-real" then emit-wat-expr ctx (list-at args 0)
+   else if n == "real-from-int" then "(i64.reinterpret_f64 (f64.convert_i64_s " & emit-wat-expr ctx (list-at args 0) & "))"
+   else if n == "real-to-int" then "(call $cx_real_to_int " & emit-wat-expr ctx (list-at args 0) & ")"
    else if n == "bit-and" then "(i64.and " & emit-wat-expr ctx (list-at args 0) & " " & emit-wat-expr ctx (list-at args 1) & ")"
    else if n == "bit-or" then "(i64.or " & emit-wat-expr ctx (list-at args 0) & " " & emit-wat-expr ctx (list-at args 1) & ")"
    else if n == "bit-xor" then "(i64.xor " & emit-wat-expr ctx (list-at args 0) & " " & emit-wat-expr ctx (list-at args 1) & ")"
@@ -1616,10 +1662,30 @@ Section: WASI Runtime Helpers
    "    (if (i32.eqz (global.get $deck_depth)) (then\n" &
    "      (global.set $deck_ptr (global.get $heap_ptr))\n" &
    "      (global.set $heap_ptr (global.get $bivy_save)))))\n" &
+   wat-rt-real-to-int &
    "  (func $codex_mod (param $a i64) (param $b i64) (result i64) (local $m i64) (local $r i64)\n" &
    "    (local.set $m (select (i64.sub (i64.const 0) (local.get $b)) (local.get $b) (i64.lt_s (local.get $b) (i64.const 0))))\n" &
    "    (local.set $r (i64.rem_s (local.get $a) (local.get $m)))\n" &
    "    (select (i64.add (local.get $r) (local.get $m)) (local.get $r) (i64.lt_s (local.get $r) (i64.const 0))))\n\n"
+
+ THE TRUNCATION IS x86's, NOT wasm's, and the difference is one input. Bare
+ metal emits `cvttsd2si` for `real-to-int` (X86_64Builtins.codex:1663-1679):
+ truncate toward zero, and the "integer indefinite" INT64_MIN for a NaN, an
+ infinity, or anything whose truncation will not fit. wasm's own
+ `i64.trunc_sat_f64_s` agrees on every one of those EXCEPT NaN, where it
+ saturates to 0, and the positive overflow, where it saturates to INT64_MAX.
+ Emitting the bare instruction would be a plausible wrong number on exactly
+ the inputs a guard exists for, so the two disagreeing cases are tested
+ first and the instruction handles the rest.
+
+  wat-rt-real-to-int : Text =
+   "  (func $cx_real_to_int (param $b i64) (result i64) (local $f f64)\n" &
+   "    (local.set $f (f64.reinterpret_i64 (local.get $b)))\n" &
+   "    (if (result i64) (f64.ne (local.get $f) (local.get $f))\n" &
+   "      (then (i64.const -9223372036854775808))\n" &
+   "      (else (if (result i64) (f64.ge (local.get $f) (f64.const 9223372036854775808))\n" &
+   "        (then (i64.const -9223372036854775808))\n" &
+   "        (else (i64.trunc_sat_f64_s (local.get $f)))))))\n\n"
 
  THE ALLOCATOR GROWS THE MEMORY, because the declared 256 pages are 16 MB
  and the compiler compiling its own source asked for an address 206 MB in.

--- a/codex/plugs/wasm/WasmEmitter.codex
+++ b/codex/plugs/wasm/WasmEmitter.codex
@@ -939,12 +939,47 @@ Section: Expression Emission
    in let stores = emit-wat-list-elems ctx elems 0 depth
    in alloc & " " & store-len & " " & store-cap & " " & stores & "(local.get $_lp)"
 
+ A LIST LITERAL IS EMITTED IN HALVES, and that is the difference between a
+ chapter emitting and a chapter exhausting the heap.
+
+ Text is immutable, so `piece & rest` allocates the whole of `piece & rest`.
+ Walking the elements left to right and concatenating as you go therefore
+ allocates THE SUM OF ITS OWN SUFFIXES -- quadratic in the number of elements,
+ for output that is linear in them. Measured 2026-08-31 with
+ `safari-codex/harness/mem_probe.py`, one definition at a time:
+
+     $g_w_trees      171,884 bytes of WAT      97.3 MB of heap
+     $g_w_cows       130,850                   53.2 MB
+     $g_w_treecolor   49,250                    9.5 MB
+
+ That is len^2/300 across all three, and `$g_kd_xy` -- one generated table in
+ one chapter -- takes the frontier from 856 MB into the 4 GiB ceiling on its
+ own. The per-definition __heap-restore below cannot help: this is all inside
+ ONE definition's bracket, which is why the ceiling is the biggest definition
+ rather than the biggest chapter.
+
+ Splitting the range in half and concatenating once copies each byte once per
+ LEVEL instead of once per remaining element: n log n, and about 50x less on
+ the numbers above. The output is byte-identical by construction -- same
+ pieces, same order, different association -- which is what makes this safe to
+ do to an emitter whose whole job is exact bytes.
+
   emit-wat-list-elems : WasmCtx, List IRExpr, Integer, Integer -> Text
   emit-wat-list-elems (ctx) (elems) (i) (depth) =
-   if i >= list-length elems then ""
-   else let off = 8 + i * 8
+   emit-wat-list-span ctx elems i (list-length elems) depth
+
+  emit-wat-list-span : WasmCtx, List IRExpr, Integer, Integer, Integer -> Text
+  emit-wat-list-span (ctx) (elems) (lo) (hi) (depth) =
+   if lo >= hi then ""
+   else if hi - lo == 1 then emit-wat-list-elem ctx elems lo depth
+   else let mid = lo + (hi - lo) / 2
+   in emit-wat-list-span ctx elems lo mid depth & emit-wat-list-span ctx elems mid hi depth
+
+  emit-wat-list-elem : WasmCtx, List IRExpr, Integer, Integer -> Text
+  emit-wat-list-elem (ctx) (elems) (i) (depth) =
+   let off = 8 + i * 8
    in wat-guard-scratch ctx (list-at elems i) "$_lp" (emit-wat-expr-at ctx (list-at elems i) (depth + 1)) &
-      "(i64.store (i32.add (i32.wrap_i64 (local.get $_lp)) (i32.const " & integer-to-text off & ")) (local.get $_tv)) " & emit-wat-list-elems ctx elems (i + 1) depth
+      "(i64.store (i32.add (i32.wrap_i64 (local.get $_lp)) (i32.const " & integer-to-text off & ")) (local.get $_tv)) "
 
   emit-wat-name : WasmCtx, Text -> Text
  `unreachable` is stack-polymorphic, so a refusal assembles wherever a value

--- a/codex/plugs/wasm/WasmEmitter.codex
+++ b/codex/plugs/wasm/WasmEmitter.codex
@@ -994,6 +994,7 @@ Section: Expression Emission
                  in if text-length sn > 0 then "(i64.extend_i32_u (i64.eqz (call " & wat-eq-fn-prefix & wat-sanitize sn & " " & emit-wat-expr-at ctx l (depth + 1) & " " & emit-wat-expr-at ctx r (depth + 1) & ")))"
                  else if wat-is-real-type (ir-expr-type l) then wat-real-cmp "f64.ne" (emit-wat-expr-at ctx l (depth + 1)) (emit-wat-expr-at ctx r (depth + 1))
                  else "(i64.extend_i32_u (" & wat-bin-instr op & " " & emit-wat-expr-at ctx l (depth + 1) & " " & emit-wat-expr-at ctx r (depth + 1) & "))"
+    is IrPowInt -> "(call $cx_ipow " & emit-wat-expr-at ctx l (depth + 1) & " " & emit-wat-expr-at ctx r (depth + 1) & ")"
     is IrLt | IrLtVec -> if wat-is-real-type (ir-expr-type l) then wat-real-cmp "f64.lt" (emit-wat-expr-at ctx l (depth + 1)) (emit-wat-expr-at ctx r (depth + 1))
               else "(i64.extend_i32_u (" & wat-bin-instr op & " " & emit-wat-expr-at ctx l (depth + 1) & " " & emit-wat-expr-at ctx r (depth + 1) & "))"
     is IrGt | IrGtVec -> if wat-is-real-type (ir-expr-type l) then wat-real-cmp "f64.gt" (emit-wat-expr-at ctx l (depth + 1)) (emit-wat-expr-at ctx r (depth + 1))
@@ -1015,7 +1016,7 @@ Section: Expression Emission
     is IrMulInt -> "i64.mul"
     is IrDivInt -> "i64.div_s"
     is IrRemInt -> "i64.rem_s"
-    is IrPowInt -> "i64.mul"
+    is IrPowInt -> "i64.pow-does-not-exist"
     is IrAddNum | IrAddRealApprox | IrAddRealTrapping | IrAddRealSaturating -> "f64.add"
     is IrSubNum | IrSubRealApprox | IrSubRealTrapping | IrSubRealSaturating -> "f64.sub"
     is IrMulNum | IrMulRealApprox | IrMulRealTrapping | IrMulRealSaturating -> "f64.mul"
@@ -1662,6 +1663,7 @@ Section: WASI Runtime Helpers
    "    (if (i32.eqz (global.get $deck_depth)) (then\n" &
    "      (global.set $deck_ptr (global.get $heap_ptr))\n" &
    "      (global.set $heap_ptr (global.get $bivy_save)))))\n" &
+   wat-rt-ipow &
    wat-rt-real-to-int &
    "  (func $codex_mod (param $a i64) (param $b i64) (result i64) (local $m i64) (local $r i64)\n" &
    "    (local.set $m (select (i64.sub (i64.const 0) (local.get $b)) (local.get $b) (i64.lt_s (local.get $b) (i64.const 0))))\n" &
@@ -1677,6 +1679,18 @@ Section: WASI Runtime Helpers
  Emitting the bare instruction would be a plausible wrong number on exactly
  the inputs a guard exists for, so the two disagreeing cases are tested
  first and the instruction handles the rest.
+
+  wat-rt-ipow : Text =
+   "  (func $cx_ipow (param $b i64) (param $e i64) (result i64)\n" &
+   "    (local $acc i64)\n" &
+   "    (local.set $acc (i64.const 1))\n" &
+   "    (if (i64.lt_s (local.get $e) (i64.const 0)) (then (return (i64.const 0))))\n" &
+   "    (block $done (loop $pow\n" &
+   "      (br_if $done (i64.eqz (local.get $e)))\n" &
+   "      (local.set $acc (i64.mul (local.get $acc) (local.get $b)))\n" &
+   "      (local.set $e (i64.sub (local.get $e) (i64.const 1)))\n" &
+   "      (br $pow)))\n" &
+   "    (local.get $acc))\n\n"
 
   wat-rt-real-to-int : Text =
    "  (func $cx_real_to_int (param $b i64) (result i64) (local $f f64)\n" &
@@ -1715,14 +1729,14 @@ Section: WASI Runtime Helpers
    "    (local.set $pos (i32.add (local.get $buf) (i32.const 23)))\n" &
    "    (local.set $neg (i64.lt_s (local.get $val) (i64.const 0)))\n" &
    "    (if (local.get $neg)\n" &
-   "      (then (local.set $abs (i64.sub (i64.const 0) (local.get $val))))\n" &
-   "      (else (local.set $abs (local.get $val))))\n" &
+   "      (then (local.set $abs (local.get $val)))\n" &
+   "      (else (local.set $abs (i64.sub (i64.const 0) (local.get $val)))))\n" &
    "    (if (i64.eqz (local.get $abs))\n" &
    "      (then (i32.store8 (local.get $pos) (i32.const 48))\n" &
    "        (local.set $pos (i32.sub (local.get $pos) (i32.const 1))))\n" &
    "      (else (block $done (loop $digits\n" &
    "          (br_if $done (i64.eqz (local.get $abs)))\n" &
-   "          (local.set $digit (i32.wrap_i64 (i64.rem_s (local.get $abs) (i64.const 10))))\n" &
+   "          (local.set $digit (i32.wrap_i64 (i64.sub (i64.const 0) (i64.rem_s (local.get $abs) (i64.const 10)))))\n" &
    "          (i32.store8 (local.get $pos) (i32.add (local.get $digit) (i32.const 48)))\n" &
    "          (local.set $pos (i32.sub (local.get $pos) (i32.const 1)))\n" &
    "          (local.set $abs (i64.div_s (local.get $abs) (i64.const 10)))\n" &
@@ -1852,14 +1866,14 @@ Section: WASI Runtime Helpers
    "    (local.set $pos (i32.add (local.get $buf) (i32.const 23)))\n" &
    "    (local.set $neg (i64.lt_s (local.get $val) (i64.const 0)))\n" &
    "    (if (local.get $neg)\n" &
-   "      (then (local.set $abs (i64.sub (i64.const 0) (local.get $val))))\n" &
-   "      (else (local.set $abs (local.get $val))))\n" &
+   "      (then (local.set $abs (local.get $val)))\n" &
+   "      (else (local.set $abs (i64.sub (i64.const 0) (local.get $val)))))\n" &
    "    (if (i64.eqz (local.get $abs))\n" &
    "      (then (i32.store8 (local.get $pos) (i32.const " & integer-to-text cce-digit-zero & "))\n" &
    "        (local.set $pos (i32.sub (local.get $pos) (i32.const 1))))\n" &
    "      (else (block $done (loop $digits\n" &
    "          (br_if $done (i64.eqz (local.get $abs)))\n" &
-   "          (local.set $digit (i32.wrap_i64 (i64.rem_s (local.get $abs) (i64.const 10))))\n" &
+   "          (local.set $digit (i32.wrap_i64 (i64.sub (i64.const 0) (i64.rem_s (local.get $abs) (i64.const 10)))))\n" &
    "          (i32.store8 (local.get $pos) (i32.add (local.get $digit) (i32.const " & integer-to-text cce-digit-zero & ")))\n" &
    "          (local.set $pos (i32.sub (local.get $pos) (i32.const 1)))\n" &
    "          (local.set $abs (i64.div_s (local.get $abs) (i64.const 10)))\n" &

--- a/codex/plugs/wasm/WasmEmitter.codex
+++ b/codex/plugs/wasm/WasmEmitter.codex
@@ -3003,13 +3003,32 @@ Section: Chapter Emission
  is a boolean and the definitions it was asked to print were never reached.
 
  An import is needed when a definition CALLS the builtin, and the IR says so
- with no allocation at all. The walk mirrors `collect-strings-expr` arm for arm,
- which is the argument for its coverage: that shape already has to reach every
- text literal in the program or the string table comes out short. Where the two
- differ is a case the text scan got WRONG: a chapter that DEFINES `blit-framebuf`
- emits `(func $blit_framebuf`, the old needle hit, and the module declared an
- import and a function under one name -- which `wat2wasm` refuses. Asking about
- call sites cannot do that.
+ with no allocation at all. The walk follows `collect-strings-expr`'s arms.
+
+ TWO THINGS THE FIRST VERSION OF THIS COMMENT CLAIMED AND SHOULD NOT HAVE, both
+ caught by a cold review and both worth leaving written down.
+
+ It said the mirroring was "the argument for its coverage: that shape already
+ has to reach every text literal in the program or the string table comes out
+ short". The shape did not, and the table did: `collect-strings-branches-loop`
+ was skipping every branch GUARD, which is fixed above. Mirroring a walker
+ inherits its blind spots, and an argument from a model is worth an audit of the
+ model.
+
+ It also said that asking about call sites could not produce the module
+ `wat2wasm` refuses -- an import and a function under one name -- the way the old
+ text scan could. It can: a chapter that defines `blit-framebuf` AND calls it
+ sets the flag through the call, and the module still carries both. Measured:
+ `error: redefinition of function "$blit_framebuf"`.
+
+ THE HONEST STATE IS THAT NEITHER IMPORT IS REACHABLE, and the two flags are one
+ hole rather than one hole and one fix. `blit-framebuf` is not a name the
+ language has -- it is nowhere in the foreword -- so a chapter that calls it
+ without defining it halts with CDX3002 and a chapter that defines it emits a
+ module the assembler refuses. `needs-blit` is therefore True only for programs
+ that cannot assemble anyway, which is exactly the shape `$on_key_import` is in
+ for a different reason. Both are recorded as a finding; the query below is
+ correct and cheap, and it is not what is wrong here.
 
   wat-expr-calls-name : IRExpr, Text -> Boolean
   wat-expr-calls-name (e) (n) =
@@ -3066,16 +3085,24 @@ Section: Chapter Emission
    else if wat-expr-calls-name ((list-at fs i).value) n then True
    else wat-fields-call-name fs n (i + 1)
 
- An empty builtin name answers False without walking, and it is not a sentinel
- for "unused": `$on_key_import` HAS no producer -- no arm of this emitter emits
- it -- so the scan that used to look for it walked every definition of every
- chapter to say False, always. The flag and its import line are kept rather than
- deleted because the hole is that `on-key` has no builtin arm, which is finding
- 1's shape, and deleting the line it guards would hide it.
+ `wasm-no-builtin` answers False without walking. It is not a sentinel for
+ "unused": `$on_key_import` HAS no producer -- no arm of this emitter emits it --
+ so the scan that used to look for it walked every definition of every chapter to
+ say False, always. The flag and its import line are kept rather than deleted
+ because the hole is that `on-key` has no builtin arm, which is finding 1's
+ shape, and deleting the line it guards would hide it.
+
+ IT IS NAMED SO THAT FILLING THE HOLE CANNOT MISS IT. Whoever adds the `on-key`
+ arm must also replace this at the call site, or the module emits a call to an
+ import it never declared and `wat2wasm` refuses it -- a flag kept as a signal,
+ wired so that acting on the signal breaks the build. A grep for the name reaches
+ every place that has to move together.
+
+  wasm-no-builtin : Text = ""
 
   wat-defs-call-name : List IRDef, Text, Integer -> Boolean
   wat-defs-call-name (defs) (n) (i) =
-   if n == "" then False
+   if n == wasm-no-builtin then False
    else if i >= list-length defs then False
    else if wat-expr-calls-name ((list-at defs i).body) n then True
    else wat-defs-call-name defs n (i + 1)
@@ -3122,7 +3149,7 @@ Section: Chapter Emission
    in let types-text = emit-wat-type-defs type-defs 0 & wat-eq-funcs type-defs 0
    in let entry = wat-emit-entry (m.defs)
    in let needs-blit = wasm-mention-any (m.defs) runtime types-text entry "$blit_framebuf" "blit-framebuf"
-   in let needs-key = wasm-mention-any (m.defs) runtime types-text entry "$on_key_import" ""
+   in let needs-key = wasm-mention-any (m.defs) runtime types-text entry "$on_key_import" wasm-no-builtin
    in let header = wat-runtime-header heap-start needs-blit needs-key
    in act
     print-uni header

--- a/codex/plugs/wasm/test/builtin-name-local-rt.codex
+++ b/codex/plugs/wasm/test/builtin-name-local-rt.codex
@@ -1,0 +1,23 @@
+Chapter: BuiltinNameLocalRt
+
+ A local binding and a parameter spelled like a builtin the plug can import.
+ Deciding whether a module needs that import by asking whether the NAME OCCURS
+ answers yes for both of these, and the module then declares an env import that
+ nothing can satisfy: it assembles, and it fails at instantiation rather than at
+ a place that names the cause.
+
+ A call is a name in the HEAD of an apply spine. Neither of these is one, and
+ neither program has any interest in the builtin.
+
+  double : Integer -> Integer
+  double (n) =
+   let blit-framebuf = n * 2
+   in blit-framebuf + blit-framebuf
+
+  hold : Integer -> Integer
+  hold (blit-framebuf) = blit-framebuf + 1
+
+  opening : [Console] Nothing = act
+   print-line-uni ("double " & show (double 21))
+   print-line-uni ("param " & show (hold 41))
+  end

--- a/codex/plugs/wasm/test/guard-nest-rt.codex
+++ b/codex/plugs/wasm/test/guard-nest-rt.codex
@@ -1,0 +1,30 @@
+Chapter: GuardNestRt
+
+ A `when` INSIDE a guard. The scrutinee is parked in a local and the else-chain
+ re-reads it for every branch below, while a guard is emitted inside that
+ chain's own condition. A match in a guard that shares the local therefore
+ overwrites the value the branches below still need, and once such a guard is
+ false every later branch dispatches on the INNER scrutinee.
+
+ `Boxed 5` is the case: its guard runs, the inner `when` replaces the scrutinee
+ with 5, the guard is false, and the `is Boxed (y)` arm below then reads a value
+ that is no longer the Boxed record. The match must be INLINE in the guard --
+ a call to a function whose body is a match is compiled as a separate function
+ with a scrutinee local of its own, and cannot collide.
+
+  Box =
+    | Boxed (Integer)
+    | Plain (Integer)
+
+  classify : Box -> Integer
+  classify (v) =
+   when v
+    is Boxed (x) when (when x is 7 -> True is otherwise -> False) -> 100
+    is Boxed (y) -> 200 + y
+    is Plain (z) -> 300 + z
+
+  opening : [Console] Nothing = act
+   print-line-uni ("boxed-7 " & show (classify (Boxed 7)))
+   print-line-uni ("boxed-5 " & show (classify (Boxed 5)))
+   print-line-uni ("plain-5 " & show (classify (Plain 5)))
+  end

--- a/codex/plugs/wasm/test/guard-string-rt.codex
+++ b/codex/plugs/wasm/test/guard-string-rt.codex
@@ -1,0 +1,25 @@
+Chapter: GuardStringRt
+
+ A text literal that appears ONLY in a match-branch guard. The string table is
+ built by walking each branch, and a walker that reads the body and never the
+ guard leaves this literal out of it; a lookup that misses answers address zero,
+ so the comparison runs against nothing at all and the module still assembles
+ and still runs.
+
+ The literals are built at run time -- "zeb" & "ra" -- so no constant folding can
+ turn the comparison into a decision the emitter makes for itself before it ever
+ reaches the string table.
+
+  Box =
+    | Boxed (Text)
+
+  classify : Text -> Text
+  classify (v) =
+   when Boxed v
+    is Boxed (x) when x == "zebra" -> "yes"
+    is otherwise -> "no"
+
+  opening : [Console] Nothing = act
+   print-line-uni ("zebra " & classify ("zeb" & "ra"))
+   print-line-uni ("other " & classify ("no" & "pe"))
+  end

--- a/codex/plugs/zig/ZigEmitter.codex
+++ b/codex/plugs/zig/ZigEmitter.codex
@@ -1945,11 +1945,35 @@ Section: Lambda and List Helpers
    in if list-length elems == 0 then "cx_ll_empty(" & et & ")"
       else "cx_ll_of(" & et & ", &[_]" & et & "{ " & emit-zig-list-elems elems 0 ctx d & " })"
 
+ JOINED ONCE, NOT RIGHT-RECURSIVELY, and this is the same hazard
+ `emit-zig-defs` already names three thousand lines down -- "joining N pieces
+ with a right-recursive `&` copies every piece it has not reached yet, so the
+ cost is the output size times the number of definitions rather than the output
+ size. Collect and join once." That note was written about the module and the
+ elements of a list literal were left doing it.
+
+ It is not a small residue. Measured 2026-08-31 through
+ `safari-codex/harness/mem_probe.py`, which reads the bump frontier between
+ phases: emitting `cat_draw-unit.codex` cost 2,549 MB of the process's 2,904 MB
+ peak, against 294 MB for the whole front end, and one generated table --
+ 467,670 bytes of zig in a single definition -- accounts for most of it. Cost
+ per byte of output grew 160 -> 375 -> 998 across pond, world and cat_draw,
+ which is the signature: a fixed cost per byte does not grow with the file.
+
+ The wasm plug had the identical defect in `emit-wat-list-elems` and 97.3 MB for
+ one 171,884-byte definition fell to 4.4 MB when it stopped. Same pieces, same
+ order, byte-identical output.
+
   emit-zig-list-elems : List IRExpr, Integer, ZigCtx, Integer -> Text
   emit-zig-list-elems (elems) (i) (ctx) (d) =
-   if i == list-length elems then ""
-   else if i == list-length elems - 1 then emit-zig-expr (list-at elems i) ctx (d + 1)
-   else emit-zig-expr (list-at elems i) ctx (d + 1) & ", " & emit-zig-list-elems elems (i + 1) ctx d
+   text-concat-list (emit-zig-list-elems-loop elems i ctx d [])
+
+  emit-zig-list-elems-loop : List IRExpr, Integer, ZigCtx, Integer, List Text -> List Text
+  emit-zig-list-elems-loop (elems) (i) (ctx) (d) (acc) =
+   if i == list-length elems then acc
+   else let one = emit-zig-expr (list-at elems i) ctx (d + 1)
+   in if i == list-length elems - 1 then list-push acc one
+   else emit-zig-list-elems-loop elems (i + 1) ctx d (list-push (list-push acc one) ", ")
 
 Section: Record Emission
 

--- a/codex/plugs/zig/ZigEmitter.codex
+++ b/codex/plugs/zig/ZigEmitter.codex
@@ -4308,14 +4308,25 @@ Section: Chapter Emission
  Integers, and an Integer is a scalar, so both survive a `__heap-restore` where
  a list would not.
 
- Split at fifty rather than sixty-four so neither mask reaches a sign bit.
+ THE SPLIT IS HALF THE TABLE, not a written-down fifty, and that is a guard
+ rather than a tidy-up. A fixed fifty sends every future part into the hi mask
+ alone: at 115 parts `bit-shl 1 65` becomes `1 << (65 & 63)` -- the emitted
+ `cx_shl` masks the shift -- so part 114 would set bit 0, marking part 50 as a
+ root it is not and failing to mark itself. That is a prelude that keeps a part
+ nothing needs and drops one that is live: the bytes move first and the zig
+ compiler complains second. A fixed fifty is also a bounds panic in the other
+ direction, since `zig-mask-lo` would walk to index 49 of a shorter table.
+
+ Half the table shares the growth, so the ceiling is 128 parts rather than 114
+ and neither end is unguarded. It is 50 today, for 100 parts, so nothing moves.
 
  The names list is threaded as a PARAMETER and not named at each use, for the
  same reason `zig-prelude-roots` already threads it: a nullary definition is a
  function, so naming it inside a loop rebuilds a hundred-element list every
  time round.
 
-  zig-prelude-split : Integer = 50
+  zig-mask-split : List Text -> Integer
+  zig-mask-split (ns) = list-length ns / 2
 
   zig-mask-loop : List Text, Text, Integer, Integer, Integer, Integer -> Integer
   zig-mask-loop (ns) (prog) (i) (hi) (base) (acc) =
@@ -4325,25 +4336,31 @@ Section: Chapter Emission
     is None -> zig-mask-loop ns prog (i + 1) hi base acc
 
   zig-mask-lo : List Text, Text -> Integer
-  zig-mask-lo (ns) (prog) = zig-mask-loop ns prog 0 zig-prelude-split 0 0
+  zig-mask-lo (ns) (prog) = zig-mask-loop ns prog 0 (zig-mask-split ns) 0 0
 
   zig-mask-hi : List Text, Text -> Integer
-  zig-mask-hi (ns) (prog) = zig-mask-loop ns prog zig-prelude-split (list-length ns) zig-prelude-split 0
+  zig-mask-hi (ns) (prog) =
+   let s = zig-mask-split ns
+   in zig-mask-loop ns prog s (list-length ns) s 0
 
- Rebuilt in `zig-prelude-part-names` order, which is the order `zig-roots-loop`
- produced them in. The two must agree name for name and position for position
- or the shake keeps a different set and the bytes move.
+ Rebuilt in `zig-prelude-part-names` order, the order `zig-roots-loop` produced
+ them in. What has to agree is the SET: `shake-kept` emits in parts-table order
+ and not in root order, so a root list in a different sequence keeps the same
+ parts. The order is matched anyway because it costs nothing and makes the two
+ comparable by eye.
+
+ `s` is threaded rather than named per iteration, the same rule as `ns` above.
 
   zig-roots-of-masks : List Text, Integer, Integer -> List Text
-  zig-roots-of-masks (ns) (m1) (m2) = zig-roots-mask-loop ns m1 m2 0 []
+  zig-roots-of-masks (ns) (m1) (m2) = zig-roots-mask-loop ns (zig-mask-split ns) m1 m2 0 []
 
-  zig-roots-mask-loop : List Text, Integer, Integer, Integer, List Text -> List Text
-  zig-roots-mask-loop (ns) (m1) (m2) (i) (acc) =
+  zig-roots-mask-loop : List Text, Integer, Integer, Integer, Integer, List Text -> List Text
+  zig-roots-mask-loop (ns) (s) (m1) (m2) (i) (acc) =
    if i >= list-length ns then acc
-   else let bit = if i < zig-prelude-split
+   else let bit = if i < s
       then bit-and (bit-shr m1 i) 1
-      else bit-and (bit-shr m2 (i - zig-prelude-split)) 1
-   in zig-roots-mask-loop ns m1 m2 (i + 1) (if bit == 1 then list-push acc (list-at ns i) else acc)
+      else bit-and (bit-shr m2 (i - s)) 1
+   in zig-roots-mask-loop ns s m1 m2 (i + 1) (if bit == 1 then list-push acc (list-at ns i) else acc)
 
   emit-zig-chapter : IRChapter, List ATypeDef -> Text
   emit-zig-chapter (m) (type-defs) =
@@ -4387,9 +4404,16 @@ Section: Chapter Emission
  streaming. The transpiler's fixed point then compares the two against each
  other, which is a better test of this change than any test written for it.
 
- Only a scalar crosses the restore. `types-text` and `main-text` are built
- before the first mark and so outlive every one of them; the per-definition
- text does not, and must not be referenced after the restore.
+ Only a scalar crosses the restore. `ctx`, `ns`, `types-text` and `main-text`
+ are all built before the first mark and so outlive every one of them -- that is
+ four things and the list has to be complete, because the next editor will trust
+ it. The per-definition text is not among them: it is allocated inside the
+ bracket and must not be referenced after the restore.
+
+ THE BARE-METAL ARM KEEPS THE OLD COST. `ZigPlugRing` calls `emit-zig-chapter`,
+ so the guest compiling this emitter still holds every definition at once, in
+ 3072 MB. The fix reaches the native binary only, and the ceiling is unfixed
+ where memory is tightest.
 
   emit-zig-chapter-stream : IRChapter, List ATypeDef -> [Console] Nothing
   emit-zig-chapter-stream (m) (type-defs) =

--- a/codex/plugs/zig/ZigEmitter.codex
+++ b/codex/plugs/zig/ZigEmitter.codex
@@ -1946,7 +1946,7 @@ Section: Lambda and List Helpers
       else "cx_ll_of(" & et & ", &[_]" & et & "{ " & emit-zig-list-elems elems 0 ctx d & " })"
 
  JOINED ONCE, NOT RIGHT-RECURSIVELY, and this is the same hazard
- `emit-zig-defs` already names three thousand lines down -- "joining N pieces
+ `emit-zig-defs` already names seventeen hundred lines down -- "joining N pieces
  with a right-recursive `&` copies every piece it has not reached yet, so the
  cost is the output size times the number of definitions rather than the output
  size. Collect and join once." That note was written about the module and the
@@ -4310,15 +4310,32 @@ Section: Chapter Emission
 
  THE SPLIT IS HALF THE TABLE, not a written-down fifty, and that is a guard
  rather than a tidy-up. A fixed fifty sends every future part into the hi mask
- alone: at 115 parts `bit-shl 1 65` becomes `1 << (65 & 63)` -- the emitted
- `cx_shl` masks the shift -- so part 114 would set bit 0, marking part 50 as a
- root it is not and failing to mark itself. That is a prelude that keeps a part
- nothing needs and drops one that is live: the bytes move first and the zig
- compiler complains second. A fixed fifty is also a bounds panic in the other
- direction, since `zig-mask-lo` would walk to index 49 of a shorter table.
+ alone: at 115 parts `bit-shl 1 64` becomes `1 << (64 & 63)` -- the emitted
+ `cx_shl` masks the shift -- so part 114 sets bit 0, the bit part 50 owns.
 
- Half the table shares the growth, so the ceiling is 128 parts rather than 114
- and neither end is unguarded. It is 50 today, for 100 parts, so nothing moves.
+ WHAT THAT COSTS IS A BLOATED PRELUDE, NOT A WRONG ONE, and the first version of
+ this comment had it backwards -- it said the prelude would keep a part nothing
+ needs AND DROP ONE THAT IS LIVE, "bytes move first and the zig compiler
+ complains second". It cannot drop one. `cx_shr` masks its shift exactly as
+ `cx_shl` does, and `zig-roots-mask-loop` reads bit `i - s` with the same
+ arithmetic the writer used, so indices that alias in the write alias in the
+ read too: either one being a root marks BOTH. That runs in the direction the
+ rule above already calls safe -- an extra root keeps a part nobody needed. The
+ real symptom is a prelude that grows and two arms that stop agreeing byte for
+ byte, which build.py's stage 8 fixed point catches by construction.
+
+ A fixed fifty is a bounds panic in the other direction, since `zig-mask-lo`
+ would walk to index 49 of a shorter table. Half the table fixes that end
+ outright: `s = N / 2` is never past the end for any N.
+
+ Half the table shares the growth, so the ceiling is 128 parts rather than 114.
+ It is 50 today, for 100 parts, so nothing moves. THE CEILING IS NOW A GUARD AND
+ NOT A HOPE: at 129 parts the two masks have run out of bits and index 128 would
+ alias index 64 in silence, which is the same defect one table-growth further
+ on, so `zig-mask-ceiling-check` emits a `@compileError` instead. Two i64 masks
+ carry 128 bits and that is the contract; the last two of them are sign bits,
+ which zig's `<<` and `>>` handle without complaint (measured, 0.16.0 Debug --
+ build.py builds without -O).
 
  The names list is threaded as a PARAMETER and not named at each use, for the
  same reason `zig-prelude-roots` already threads it: a nullary definition is a
@@ -4327,6 +4344,15 @@ Section: Chapter Emission
 
   zig-mask-split : List Text -> Integer
   zig-mask-split (ns) = list-length ns / 2
+
+  zig-mask-ceiling-check : List Text -> Text
+  zig-mask-ceiling-check (ns) =
+   if list-length ns <= 128 then ""
+   else "comptime { @compileError(\"cx zig plug: the prelude parts table has "
+        & integer-to-text (list-length ns)
+        & " parts and the two-mask shake answer carries 128. Add a third mask to"
+        & " zig-mask-lo/hi and zig-roots-mask-loop, or the shake keeps the wrong"
+        & " set in silence.\"); }\n"
 
   zig-mask-loop : List Text, Text, Integer, Integer, Integer, Integer -> Integer
   zig-mask-loop (ns) (prog) (i) (hi) (base) (acc) =
@@ -4399,16 +4425,22 @@ Section: Chapter Emission
  took from it.
 
  `emit-zig-chapter` is KEPT and is not a fallback: `ZigPlug`, `ZigStdio` and
- `ZigPlugRing` still call it, so the ring plug that compiles this emitter on
+ `ZigPlugRing` (the last of which is not in this repo -- it is
+ `source/ZigPlugRing.codex` in the codexzig worktree) still call it, so the ring plug that compiles this emitter on
  bare metal emits a module the whole-text way while the native binary emits it
  streaming. The transpiler's fixed point then compares the two against each
  other, which is a better test of this change than any test written for it.
 
- Only a scalar crosses the restore. `ctx`, `ns`, `types-text` and `main-text`
- are all built before the first mark and so outlive every one of them -- that is
- four things and the list has to be complete, because the next editor will trust
- it. The per-definition text is not among them: it is allocated inside the
- bracket and must not be referenced after the restore.
+ Only a scalar crosses the restore. What must be allocated BEFORE the first
+ mark is everything `zig-stream-defs` dereferences after one: `ctx`, `ns`,
+ `main-text`, and `defs` -- which is `m.defs`, the caller's allocation from
+ `parse-ir-chapter`, and is the one an enumeration exists to record because
+ nothing here allocates it. FOUR things, and the list has to be complete because
+ the next editor will trust it. `types-text` is NOT among them, though an
+ earlier version of this list said it was: it is printed before `zig-stream-defs`
+ is entered, is never passed in, and outlives nothing. The per-definition text is
+ not among them either -- it is allocated inside the bracket and must not be
+ referenced after the restore.
 
  THE BARE-METAL ARM KEEPS THE OLD COST. `ZigPlugRing` calls `emit-zig-chapter`,
  so the guest compiling this emitter still holds every definition at once, in
@@ -4436,6 +4468,7 @@ Section: Chapter Emission
    in let m1 = bit-or (zig-mask-lo ns types-text) (zig-mask-lo ns main-text)
    in let m2 = bit-or (zig-mask-hi ns types-text) (zig-mask-hi ns main-text)
    in act
+    print-uni (zig-mask-ceiling-check ns)
     print-uni types-text
     zig-stream-defs ctx (m.defs) 0 main-text ns m1 m2
    end

--- a/codex/plugs/zig/ZigEmitter.codex
+++ b/codex/plugs/zig/ZigEmitter.codex
@@ -4299,6 +4299,52 @@ Section: Chapter Emission
   zig-prelude : Text = shake-text zig-prelude-parts zig-prelude-part-names
 
 
+ THE PRELUDE IS A FUNCTION OF THE EMITTED PROGRAM, which is what stands
+ between this emitter and the streaming shape the wasm plug uses.
+ `zig-prelude-for` searches the whole program text for each of the hundred part
+ names, so a version that prints a definition and forgets it has nothing left
+ to search. The answer is to ask the question definition by definition and
+ carry only the ANSWER across the boundary: a hundred yes/no bits is two
+ Integers, and an Integer is a scalar, so both survive a `__heap-restore` where
+ a list would not.
+
+ Split at fifty rather than sixty-four so neither mask reaches a sign bit.
+
+ The names list is threaded as a PARAMETER and not named at each use, for the
+ same reason `zig-prelude-roots` already threads it: a nullary definition is a
+ function, so naming it inside a loop rebuilds a hundred-element list every
+ time round.
+
+  zig-prelude-split : Integer = 50
+
+  zig-mask-loop : List Text, Text, Integer, Integer, Integer, Integer -> Integer
+  zig-mask-loop (ns) (prog) (i) (hi) (base) (acc) =
+   if i >= hi then acc
+   else when index-of prog (list-at ns i)
+    is Just (at) -> zig-mask-loop ns prog (i + 1) hi base (bit-or acc (bit-shl 1 (i - base)))
+    is None -> zig-mask-loop ns prog (i + 1) hi base acc
+
+  zig-mask-lo : List Text, Text -> Integer
+  zig-mask-lo (ns) (prog) = zig-mask-loop ns prog 0 zig-prelude-split 0 0
+
+  zig-mask-hi : List Text, Text -> Integer
+  zig-mask-hi (ns) (prog) = zig-mask-loop ns prog zig-prelude-split (list-length ns) zig-prelude-split 0
+
+ Rebuilt in `zig-prelude-part-names` order, which is the order `zig-roots-loop`
+ produced them in. The two must agree name for name and position for position
+ or the shake keeps a different set and the bytes move.
+
+  zig-roots-of-masks : List Text, Integer, Integer -> List Text
+  zig-roots-of-masks (ns) (m1) (m2) = zig-roots-mask-loop ns m1 m2 0 []
+
+  zig-roots-mask-loop : List Text, Integer, Integer, Integer, List Text -> List Text
+  zig-roots-mask-loop (ns) (m1) (m2) (i) (acc) =
+   if i >= list-length ns then acc
+   else let bit = if i < zig-prelude-split
+      then bit-and (bit-shr m1 i) 1
+      else bit-and (bit-shr m2 (i - zig-prelude-split)) 1
+   in zig-roots-mask-loop ns m1 m2 (i + 1) (if bit == 1 then list-push acc (list-at ns i) else acc)
+
   emit-zig-chapter : IRChapter, List ATypeDef -> Text
   emit-zig-chapter (m) (type-defs) =
    let ctx = ZigCtx {
@@ -4318,5 +4364,73 @@ Section: Chapter Emission
    in let defs-text = emit-zig-defs (m.defs) 0 ctx
    in let zig-prog = types-text & defs-text & zig-main opening-entry-point (m.defs)
    in zig-prog & zig-postlude-banner & zig-prelude-for zig-prog
+
+ THE SAME MODULE, ONE DEFINITION AT A TIME. `emit-zig-chapter` above holds
+ every definition's working set at once, because a bump allocator with no GC
+ keeps everything a definition allocated until the function that made it
+ returns and nothing here returns until the whole module is built. Measured
+ 2026-08-31 with `safari-codex/harness/mem_probe.py`, which reads the frontier
+ between phases: emitting `cat_draw-unit.codex` cost 398 MB against 294 MB for
+ the entire front end, and it is a SUM over definitions rather than a max --
+ about 150 bytes of heap per byte of output, flat, so it grows with the module
+ and there is no unit large enough to be safe, only units small enough to have
+ got away with it.
+
+ Marking the heap, emitting ONE definition, printing it and restoring the mark
+ makes the cost the max instead. It is the shape `emit-streaming-ir-defs` uses
+ in the compiler's own `opening.codex` and the one `emit-wasm-chapter-stream`
+ took from it.
+
+ `emit-zig-chapter` is KEPT and is not a fallback: `ZigPlug`, `ZigStdio` and
+ `ZigPlugRing` still call it, so the ring plug that compiles this emitter on
+ bare metal emits a module the whole-text way while the native binary emits it
+ streaming. The transpiler's fixed point then compares the two against each
+ other, which is a better test of this change than any test written for it.
+
+ Only a scalar crosses the restore. `types-text` and `main-text` are built
+ before the first mark and so outlive every one of them; the per-definition
+ text does not, and must not be referenced after the restore.
+
+  emit-zig-chapter-stream : IRChapter, List ATypeDef -> [Console] Nothing
+  emit-zig-chapter-stream (m) (type-defs) =
+   let ctx = ZigCtx {
+    arities = build-arity-map (m.defs) 0 [],
+    ctors = build-ctor-map type-defs 0 [],
+    typedefs = type-defs,
+    irdefs = m.defs,
+    renamed-from = [],
+    renamed-to = [],
+    tvar-ids = [],
+    tvar-types = [],
+    expected = VoidTy,
+    bound-names = [],
+    scope-tvars = []
+   }
+   in let ns = zig-prelude-part-names
+   in let types-text = emit-zig-type-defs type-defs 0
+   in let main-text = zig-main opening-entry-point (m.defs)
+   in let m1 = bit-or (zig-mask-lo ns types-text) (zig-mask-lo ns main-text)
+   in let m2 = bit-or (zig-mask-hi ns types-text) (zig-mask-hi ns main-text)
+   in act
+    print-uni types-text
+    zig-stream-defs ctx (m.defs) 0 main-text ns m1 m2
+   end
+
+  zig-stream-defs : ZigCtx, List IRDef, Integer, Text, List Text, Integer, Integer -> [Console] Nothing
+  zig-stream-defs (ctx) (defs) (i) (main-text) (ns) (m1) (m2) =
+   if i >= list-length defs then act
+    print-uni main-text
+    print-uni zig-postlude-banner
+    print-uni (shake-text zig-prelude-parts (zig-roots-of-masks ns m1 m2))
+   end
+   else let h = __heap-save
+   in let text = emit-zig-def (list-at defs i) ctx
+   in let n1 = bit-or m1 (zig-mask-lo ns text)
+   in let n2 = bit-or m2 (zig-mask-hi ns text)
+   in act
+    print-uni text
+    let restored = __heap-restore h
+    in zig-stream-defs ctx defs (i + 1) main-text ns n1 n2
+   end
 
 Page 1


### PR DESCRIPTION
Claude here, working with Steve Howell on the zig phase-oracle ladder.

Eleven commits from porting a driving screensaver from Zig to Codex and then running the same programs through `codex/plugs/wasm` beside `codex/plugs/zig` and requiring the two to agree. **Four of them are silent wrong answers** — modules that assemble, run, and print something other than what bare metal prints: `a ^ b`, `show` of INT64_MIN, a text literal in a guard, and a `when` inside a guard. A fifth defect is the opposite shape, a refusal: no program computing with `Real` had ever assembled at all. The rest are a 4 GiB ceiling in both emitters, and the corrections two cold reviews forced on our own first attempts.

Two files, no compiler change: `codex/plugs/wasm/WasmEmitter.codex` and `codex/plugs/zig/ZigEmitter.codex`.

## This is independent of PRs 100, 101, 103, 105, 107 and 108

The branch is cut from **Update 53 itself**, and every commit cherry-picked onto it clean. Nothing here is stacked on anything. Our port needs PR 100 and PR 105 for its own checks, but this branch does not: it builds a working transpiler on plain Update 53, and the fixed point holds there (below).

## Why one PR rather than eleven

Three of these commits **correct earlier ones in the same series** — `f713ccc3` corrects prose in `d19bf032`, `3ceabf05` corrects a claim in `f713ccc3`, and `622c3083` corrects the comment in `e06e700f`. Splitting the series would either hide that record or force a rewrite of it, and the record is the most useful part: each of those corrections came from a cold review of the commit before, and each found something the test sweep could not.

Each commit is still one thing, so the series reads commit by commit.

## The map

| commit | plug | what |
|---|---|---|
| `b5ffdfe7` | wasm | `Real` was carried as an i64 with f64 bits in it — no program computing with `Real` had ever assembled |
| `8c2899c3` | wasm | **`a ^ b` emitted `a * b`**, and `show` of INT64_MIN printed garbage bytes |
| `d19bf032` | wasm | ask the IR which imports a module needs, instead of scanning the emitted text twice |
| `cbd98ab8` | wasm | emit a list literal in halves — the 4 GiB ceiling goes away |
| `27a1812b` | zig | join a list literal's elements once, as `emit-zig-defs` already says to |
| `4a5fc6a3` | zig | emit a chapter one definition at a time, carrying the prelude's answer across the restore |
| `31213e60` | wasm | **a branch's GUARD is part of the branch** — a literal only in a guard compared against address zero |
| `e06e700f` | zig | size the prelude mask split to the table instead of a written-down fifty |
| `f713ccc3` | wasm | neither `env` import is reachable, and the comment said one was fixed |
| `3ceabf05` | wasm | **a guard needs its own scrutinee local**, and a mention is not a call |
| `622c3083` | both | the mask split's stated failure mode was impossible; the ceiling is a gate now |

## The wrong answers, which is what to review hardest

**`a ^ b` emitted `a * b`.** `2 ^ 10` printed 20. `Desugarer.codex:257` maps `Caret` to `OpPow` and `LoweringTypes.codex:186` maps `OpPow` to `IrPowInt`; the plug's binary-op table had no `IrPowInt` arm and fell through to multiply. There is now a `$cx_ipow` and the table's fallthrough names itself.

**A text literal that appears only in a match-branch GUARD** never reached the string table, because the walker read each branch's body and not its guard. A lookup that misses answers 0, so the comparison ran against address zero. It assembles; it answers wrong. `codex/plugs/wasm/test/guard-string-rt.codex`.

**A `when` inside a guard overwrote the scrutinee** the branches below still needed. The scrutinee is parked in one per-function local and the else-chain re-reads it, while the guard is emitted inside that chain's condition:

```
is Boxed (x) when (when x is 7 -> True is otherwise -> False) -> 100
is Boxed (y) -> 200 + y
```

bare metal `100 / 205 / 305`, the wasm plug `100 / 720575940396056776 / 305` — a pointer read as an integer. The scrutinee local is now per guard-nesting depth, with unary names (`_s`, `_ss`) so the locals collector shifts a guard's names by one and merges rather than threading a depth it could get out of step with. A match in a branch BODY still shares the local, which is correct: once a body is selected the else-chain is dead. `codex/plugs/wasm/test/guard-nest-rt.codex`.

**`Real` was an i64 with f64 bits in it** — the refusal rather than a silent answer, since nothing computing with `Real` assembled. `f64.add` was handed two i64s; the four ordered comparisons emitted `i64.lt_s` on bit patterns, so every negative real sorted above every positive one and `-2.0 < -1.0` came out False.

## The ceiling, in both plugs

Both emitters built their whole output by right-recursive `&`, which copies every piece it has not reached yet — the cost is output size times definition count rather than output size. `ZigEmitter` already had a note saying exactly that about the module, seventeen hundred lines from where the list-literal join was doing it anyway.

Measured on our largest unit, peak RSS of the plain binaries: `cat_draw` **2,904 MB → 418 MB** on the zig arm (`27a1812b` then `4a5fc6a3`), and on the wasm arm the 4 GiB reserve stopped being exceeded at all — three units could not emit a module before `cbd98ab8` and all seventeen do now, the largest at 679 MB.

`4a5fc6a3` is the one to look at closely: emitting a chapter one definition at a time means the prelude's tree-shake answer has to cross a `__heap-restore`, so it is carried as two i64 masks instead of a list. `e06e700f` sizes the split to half the table, and `622c3083` makes the 128-part ceiling a `@compileError` rather than a silent aliasing — with the reasoning corrected: an alias marks *both* parts, because `cx_shr` masks its shift exactly as `cx_shl` does, so it can never drop a live root. It bloats the prelude and breaks byte-identity, which the fixed point catches.

## What we did not fix, on purpose

- **Text-literal PATTERNS** (`when t is "sin" ->`) still splice the spelling into `(i64.const sin)` and `wat2wasm` refuses the module by name. It is a supported feature with tests under `codex/test`. It fails loudly, so we left it; closing it needs three things, not one, and the comment in `31213e60` says which three.
- **Neither `env` import is reachable by any program that assembles.** `blit-framebuf` is not a name the language has — nowhere in the foreword — so calling it halts at CDX3002 and defining it emits an import and a function under one name that `wat2wasm` refuses (measured: `error: redefinition of function "$blit_framebuf"`). `$on_key_import` has no producer at all. That is a question for you rather than a fix from outside, and `f713ccc3` records it.
- `show` on a `Real` prints its bit pattern; the vector ops have the `Real` shape; a module's exports are decided by a 484-name allowlist drawn from unrelated applications. All recorded, none touched here.

## Tests

Three new files in `codex/plugs/wasm/test/`, in the convention the others use — a chapter with prose, printing lines, no `.expected` because your harness grades against the x86-64 run:

- `guard-string-rt.codex` — a literal only in a guard, built at run time so nothing folds it
- `guard-nest-rt.codex` — a `when` inside a guard
- `builtin-name-local-rt.codex` — a local and a parameter spelled `blit-framebuf`

**How they were graded.** We could not run `wasm-e2e.ps1` here: it needs `build-output/wasm-plug.cdx` built through your `build.ps1`, which this box does not have. So each test was run on **three** arms instead — the Codex compiler's own x86-64 emitter as a kernel image under QEMU (the truth), the zig plug, and the wasm plug — and all three must print the same bytes. **All three agree, with bare metal as the reference.**

And each one fails on the wasm arm at the commit just before its fix, which is the part that makes a test worth keeping:

| test | before | now |
|---|---|---|
| `guard-string-rt` | `zebra no` | `zebra yes` |
| `guard-nest-rt` | `boxed-5 720575940396056776` | `boxed-5 205` |
| `builtin-name-local-rt` | module dies: `unknown import: env::blit_framebuf` | `double 84 / param 42` |

## How the branch was verified

- **The fixed point HOLDS on this branch alone**, off plain Update 53: our transpiler emits byte-identical output for its own source whether it runs on bare metal under QEMU or as the native binary that run produced — **2,448,436 bytes each way**, nine stages, three guests, 441s. `arith.codex` then matched its expected output on all nine lines.
- **27 units emit byte-identical zig** against the compiler from before any of this work — so the zig-plug commits are inert on output and change only what emitting costs.
- 10 differential probes, wasm plug against zig plug, both native.
- Our port's own sweep is GREEN across 17 checks on both arms.

One honest caveat about that byte-identity, because it would be easy to over-read: **it is not evidence for the guard fixes.** There are no guarded match arms anywhere in our port, so identical output there was guaranteed by construction. The tests above are the evidence for those, and they are the reason the tests exist.

## Provenance

Everything here was found in ordinary use — porting a game — rather than by hunting, except the last three, which a cold review of the first eight found. That review is also why three commits correct earlier ones: an argument from a model of a walker is worth an audit of the walker, and twice it was not.
