### PR TITLE
zig plug: a closure parameter named p0 collides with a source p0, so name them in the emitter's namespace

### DIFF
--- a/codex/plugs/plugs-backlog.md
+++ b/codex/plugs/plugs-backlog.md
@@ -6662,6 +6662,28 @@ advanced: `apps/classics-test` moved off `undefined local variable $real_to_int`
 to a wrong answer. The fix state was hashed before the control ran and verified
 after restoring it.
 
+## 2.20 -- CONTRIBUTED by Steve Howell (PR pending, 2026-09-03): an emitted closure parameter was named `p0`, which zig refuses when the Codex source has its own `p0`
+
+`zig-closure-pass` and `zig-closure-params` named a lambda's parameters `p0`,
+`p1`, ... Zig forbids shadowing, so a Codex definition holding a local of the
+same name emitted invalid zig -- "function parameter 'p0' shadows local
+constant from outer scope" -- and nothing in the emitter could see it coming,
+because the colliding name is one the SOURCE chose.
+
+Update 54 made it live. `check-chapter`'s CHECK-REG instrumentation binds
+`p0`..`p5` (`"CHECK-REG tdm=" & show (p1 - p0) & ...`), and `check-chapter`
+also builds its slug cache with a comprehension, which is a closure. That put
+a `p0` parameter inside a scope already holding a `p0` constant.
+
+`_cp` puts closure parameters where `_Env`, `_ctx` and `__lam_` already are:
+the emitter's own namespace, which a Codex identifier cannot sanitize into.
+The class of defect is the general one -- an emitter naming anything in the
+program's namespace is one source identifier away from a collision -- and this
+fix closes the instance rather than the class.
+
+MEASURED: the compiler transpiles and `native/codexir` builds. NOT MEASURED:
+Damian's gate; no non-zig plug touched. Steve Howell's lane (COMPILER-13).
+
 ## 2.18 -- DONE 2026-09-01 (contributed by Steve Howell, PRs 111 and 112; absorbed by red): the wasm plug's silent wrong answers, the 4 MiB truncation, the 4 GiB ceiling and the corpus refusals; the zig plug streams
 
 Both PRs were cut from Update 53 and rebased here onto the 60-of-60 emitter

--- a/codex/plugs/zig/ZigEmitter.codex
+++ b/codex/plugs/zig/ZigEmitter.codex
@@ -2815,15 +2815,25 @@ Section: Apply Emission
   zig-closure-pass : Integer, Integer -> Text
   zig-closure-pass (n) (i) =
    if i >= n then ""
-   else let one = "p" & integer-to-text i
+   else let one = "_cp" & integer-to-text i
    in if i == n - 1 then one else one & ", " & zig-closure-pass n (i + 1)
+
+ A CLOSURE PARAMETER IS IN THE EMITTER'S NAMESPACE, NOT THE PROGRAM'S.
+ These were `p0`, `p1`, ... and zig forbids shadowing, so a Codex definition
+ with a local of the same name emitted invalid zig -- "function parameter 'p0'
+ shadows local constant from outer scope", and nothing here could see it
+ because the collision is with a name the SOURCE chose. Update 54 made it live:
+ check-chapter's CHECK-REG instrumentation binds p0..p5.
+
+ `_cp` puts them where `_Env`, `_ctx` and `__lam_` already are. A Codex
+ identifier cannot sanitize into that prefix.
 
   zig-closure-params : CodexType, Integer, List (Integer between 0 and 4294967295) -> Text
   zig-closure-params (ty) (i) (scope) =
    when zig-fn-spine ty
     is FunTy (p) (fnrow) (r) ->
      let rest = zig-closure-params r (i + 1) scope
-     in "p" & integer-to-text i & ": " & emit-zig-type p scope
+     in "_cp" & integer-to-text i & ": " & emit-zig-type p scope
       & (if text-length rest == 0 then "" else ", " & rest)
     is otherwise -> ""
 
@@ -2844,7 +2854,7 @@ Section: Apply Emission
 
   zig-closure-pass-tail : Integer, Integer -> Text
   zig-closure-pass-tail (i) (n) =
-   if i >= n then "" else ", p" & integer-to-text i & zig-closure-pass-tail (i + 1) n
+   if i >= n then "" else ", _cp" & integer-to-text i & zig-closure-pass-tail (i + 1) n
 
   zig-closure-call-body : Text, Integer, Text, Integer, Integer, Integer, Text -> Text
   zig-closure-call-body (n) (nargs) (ev) (flat) (rem) (d) (targs) =


### PR DESCRIPTION
Backlog row: `codex/plugs/plugs-backlog.md` **2.20** (added in this PR). Zig plug only. Independent of #118, though both were found by the same build.

## Why

`zig-closure-pass` and `zig-closure-params` named a lambda's parameters `p0`, `p1`, ... Zig forbids shadowing, so a Codex definition holding a local of the same name emits invalid zig:

```
function parameter 'p0' shadows local constant from outer scope
```

**The emitter could not see it coming**, because the colliding name is one the *source* chose.

Update 54 made it live. `check-chapter`'s CHECK-REG instrumentation binds `p0`..`p5`:

```
"CHECK-REG tdm=" & show (p1 - p0) & ...
```

and `check-chapter` also builds its slug cache with a comprehension, which is a closure. That put a `p0` parameter inside a scope already holding a `p0` constant.

## The fix

`_cp0`, `_cp1`, ... — putting closure parameters where `_Env`, `_ctx` and `__lam_` already live: the emitter's own namespace, which a Codex identifier cannot sanitize into.

Worth naming the general shape, since this is only one instance of it: **an emitter that names anything in the program's namespace is one source identifier away from a collision.** This PR closes the instance. Whether any other emitted name in `ZigEmitter` is still in the program's namespace is not something I audited — I fixed what the build hit.

## What is measured, and what is not

**Measured.** The compiler transpiles and `native/codexir` builds and runs. This was found by that build: after the missing builtins in #118 were added, transpilation got through for the first time and landed straight on this.

**Not measured.** I have not run your gate. No non-zig plug was touched. I have not constructed a minimal reproducer — the case that found it is the compiler's own `check-chapter`, which is a large subject; a two-line Codex program with a `p0` local and a comprehension should reproduce it, and I have not written one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xx6WUU15FAVmVruJFs8sH3