### PR TITLE
zig plug: emit real-to-int and real-from-int (replaces #100, no cross-graded expectation)

### DIFF
--- a/codex/plugs/plugs-backlog.md
+++ b/codex/plugs/plugs-backlog.md
@@ -7500,6 +7500,33 @@ plug fingerprint beside it already guards the EMITTER for this reason; this guar
 the SOURCE. Calibrated both ways: the stale concat exits 2 with the refusal, the
 regenerated one passes.
 
+## 2.29 -- OPEN (Steve Howell, 2026-09-05): the zig plug cannot emit real-to-int or real-from-int, and run.ps1 chose a kernel it did not pass
+
+The plug emits `real-to-bits` and `bits-to-real` and neither of the two
+CONVERSIONS beside them. A program that turns a Real into an Integer, or back,
+refuses at the emitter -- and `show` on a Real routes through the same
+conversion, so it is not an exotic path.
+
+The emitter is the increment; the EXPECTATION is what kept the earlier attempt
+out, and that part is settled now. PR 100 put NaN, infinity and overflow rows
+in `codex/test/ops`, which `build/test-cross-batch.ps1` also grades on arm64
+and riscv64, and those three cases are exactly where the ISAs disagree: x86
+answers the integer indefinite, arm64 and riscv saturate. `real-to-int-wide`
+now carries the unambiguous range for all three backends, so nothing here adds
+a cross-graded expectation at all.
+
+Measured, transpiled and RUN rather than read: `real-from-int` then
+`real-to-int` round-trips 3000000000 and -3000000000 -- above 2^31 on purpose,
+the range a 32-bit conversion saturates in -- and `real-to-int` truncates 2.75
+to 2 and -2.75 to -2, toward zero rather than toward the floor.
+
+Also here: `run.ps1` creates the `build-output` directory it writes its log
+into, and passes `-Kernel` in BOTH branches. Testing an ABSOLUTE path and then
+passing nothing left `compile.ps1` on its own RELATIVE default, so from any
+working directory but the repo root the test passed and the compile failed
+anyway. Related to 2.26, which is about the same scripts sharing a fixed
+scratch path, and not the same defect.
+
 ## 2.28 -- findings routed from Steve Howell's safari-codex intake, UNVERIFIED
 
 Routed as pointers by val on 2026-09-02 during the safari intake (`apps/safari`,

--- a/codex/plugs/zig/ZigEmitter.codex
+++ b/codex/plugs/zig/ZigEmitter.codex
@@ -104,6 +104,7 @@ Section: Keywords and Sanitization
    "cx_ll_concat", "cx_ll_cons", "cx_ll_insert_at", "cx_ll_with_capacity",
    "cx_text_compare", "cx_text_to_double_bits", "cx_bits_to_real_approx",
    "cx_real_to_bits", "cx_bits_to_real",
+   "cx_real_to_int", "cx_real_from_int",
    "cx_char_to_text", "cx_char_encode", "cx_list_len", "cx_list_at",
    "cx_text_len", "cx_char_at", "cx_text_dup", "cx_substring", "cx_ipow",
    "cx_shl", "cx_shr", "cx_heap_base", "cx_buf_want", "cx_frontier_crosses",
@@ -1081,6 +1082,8 @@ Section: Builtin Emitter
     ZigBuiltinEmitter { name = "bits-to-real-approx", emit = \args ctx d ty -> "cx_bits_to_real_approx(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "real-to-bits", emit = \args ctx d ty -> "cx_real_to_bits(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "bits-to-real", emit = \args ctx d ty -> "cx_bits_to_real(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
+    ZigBuiltinEmitter { name = "real-from-int", emit = \args ctx d ty -> "cx_real_from_int(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
+    ZigBuiltinEmitter { name = "real-to-int", emit = \args ctx d ty -> "cx_real_to_int(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "print-error", emit = \args ctx d ty -> "cx_print_line(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "print-error-uni", emit = \args ctx d ty -> "cx_print_line(" & emit-zig-expr (list-at args 0) ctx (d + 1) & ")" },
     ZigBuiltinEmitter { name = "show", emit = \args ctx d ty -> zig-show-arg (list-at args 0) ctx d },
@@ -3963,6 +3966,12 @@ Section: Chapter Emission
   zig-p-cx-bits-to-real : List ShakeFrag
   zig-p-cx-bits-to-real = [ShakeLit "// mov-rr on bare metal (emit-bits-to-real-builtin), the same register move in\n// the other direction, and the exact inverse of cx_real_to_bits above. Total\n// likewise: every i64 names an f64, the NaNs and the infinities included.\nfn ", ShakeUse "cx_bits_to_real", ShakeLit "(n: i64) f64 {\n    return @bitCast(n);\n}\n"]
 
+  zig-p-cx-real-from-int : List ShakeFrag
+  zig-p-cx-real-from-int = [ShakeLit "// cvtsi2sd on bare metal (emit-real-from-int-builtin): a signed i64 to\n// f64 in the default rounding mode, which is round-to-nearest-even.\n// @floatFromInt is that same conversion -- exact below 2^53 and correctly\n// rounded above it -- so the two arms agree at every magnitude.\nfn ", ShakeUse "cx_real_from_int", ShakeLit "(n: i64) f64 {\n    return @floatFromInt(n);\n}\n"]
+
+  zig-p-cx-real-to-int : List ShakeFrag
+  zig-p-cx-real-to-int = [ShakeLit "// cvttsd2si on bare metal (emit-real-to-int-builtin): truncate toward\n// zero, and answer x86's \"integer indefinite\" -- INT64_MIN -- for a NaN,\n// for an infinity, and for anything whose truncation will not fit i64.\n// Zig's @intFromFloat truncates the same way but is UNDEFINED out of\n// range, so these guards are the mirror of what the hardware actually\n// answers rather than decoration: without them the out-of-range cases are\n// not merely a different answer from bare metal, they are no answer at\n// all. 2^63 is exact in f64, so both bounds are exact and the comparisons\n// catch the infinities on the way past.\nfn ", ShakeUse "cx_real_to_int", ShakeLit "(v: f64) i64 {\n    if (v != v) return -9223372036854775808;\n    if (v >= 9223372036854775808.0) return -9223372036854775808;\n    if (v < -9223372036854775808.0) return -9223372036854775808;\n    return @intFromFloat(v);\n}\n"]
+
   zig-p-cx-char-to-text : List ShakeFrag
   zig-p-cx-char-to-text = [ShakeLit "// A char is a CCE code and text is CCE, so making text from a char is\n// ONE raw byte, the way bare metal does: emit-char-to-text-builtin stores\n// the code with mov-store-byte, length 1, no framing, truncating silently\n// past 255. Byte-wise text rebuilds (ir-quote walks char-code-at /\n// code-to-char / char-to-text over every byte) rely on that identity to\n// pass CCE frame bytes through untouched; framing or converting here\n// corrupts the wire.\nfn ", ShakeUse "cx_char_to_text", ShakeLit "(c: i64) []const u8 {\n    const b = ", ShakeUse "cx_gpa", ShakeLit ".alloc(u8, 1) catch @panic(\"oom\");\n    b[0] = @truncate(@as(u64, @bitCast(c)));\n    return b;\n}\n"]
 
@@ -4222,6 +4231,8 @@ Section: Chapter Emission
     ShakePart { name = "cx_bits_to_real_approx", frags = zig-p-cx-bits-to-real-approx },
     ShakePart { name = "cx_real_to_bits", frags = zig-p-cx-real-to-bits },
     ShakePart { name = "cx_bits_to_real", frags = zig-p-cx-bits-to-real },
+    ShakePart { name = "cx_real_from_int", frags = zig-p-cx-real-from-int },
+    ShakePart { name = "cx_real_to_int", frags = zig-p-cx-real-to-int },
     ShakePart { name = "cx_char_to_text", frags = zig-p-cx-char-to-text },
     ShakePart { name = "cx_char_encode", frags = zig-p-cx-char-encode },
     ShakePart { name = "cx_list_len", frags = zig-p-cx-list-len },

--- a/codex/plugs/zig/run.ps1
+++ b/codex/plugs/zig/run.ps1
@@ -13,12 +13,35 @@ $OutDir  = Join-Path $PSScriptRoot 'build-output'
 $IrFile  = Join-Path $OutDir 'last-run.ir'
 $LogFile = Join-Path $OutDir 'run.log'
 
+# The directory this writes its IR and its log into. Nothing else creates it,
+# so in a fresh checkout compile.ps1 was asked to write a log into a directory
+# that does not exist, and the failure surfaced as "IR compile failed; see
+# <that log>" -- naming a file it had just been unable to create.
+New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+
+# compile.ps1 wants the SELF-HOSTED kernel that build.ps1 produces and refuses
+# with "run build.ps1 first, or pass -Kernel seed\Codex.cdx" when it is absent.
+# Take it at its word: use the self-hosted kernel when there is one and the
+# seed when there is not, rather than requiring a full build.ps1 before the
+# plug can be run at all. The plug's output does not depend on which compiler
+# produced the IR it is handed.
+#
+# -Kernel IS PASSED IN BOTH BRANCHES, and that is the half a first version of
+# this got wrong. Testing an ABSOLUTE path and then passing nothing leaves
+# compile.ps1 on its own default, which is RELATIVE: from any working
+# directory but the repo root the test passes and the compile fails anyway.
+# Passing it explicitly also puts the choice in the `kernel:` digest line,
+# where a reader can see which compiler produced the IR.
+$Kernel = Join-Path $Repo 'build-output' 'bare-metal' 'Codex.cdx'
+if (-not (Test-Path $Kernel)) { $Kernel = Join-Path $Repo 'seed' 'Codex.cdx' }
+$KernelArgs = @('-Kernel', $Kernel)
+
 # -Passes 'text-plug' is what a SOURCE plug must receive: the default pipeline
 # inlines, and an inlined call site never reaches the emitter at all. Measured
 # on plug-oracle-arith, the default inlines the one call whose arguments are
 # both literals and both list-literal helpers, so the emitter is graded on a
 # program it is not handed in service (plugs-backlog 1.15).
-& pwsh -NoProfile -File (Join-Path $Repo 'build\compile.ps1') -Src $Src -Out $IrFile -Log $LogFile -IrCce -Passes 'text-plug' 2>&1 | Out-Null
+& pwsh -NoProfile -File (Join-Path $Repo 'build\compile.ps1') -Src $Src -Out $IrFile -Log $LogFile -IrCce -Passes 'text-plug' @KernelArgs 2>&1 | Out-Null
 if ($LASTEXITCODE -ne 0 -or -not (Test-Path $IrFile)) {
     [Console]::Error.WriteLine("FAIL: IR compile failed; see $LogFile")
     exit 4


### PR DESCRIPTION
Replaces #100, which is closed. One commit, cut from `675a0775` (Update 55)
with no stack under it. **The test that blocked #100 is not here** — the
question it raised is settled upstream.

`Ladder: zig-real-int-conversions`

---

## What the review said, and what changed

#100's review found the emitter correct: NaN caught by `v != v`, both
infinities by the range tests, the top bound exact, `-2^63` admitted by `<`
rather than `<=`, `-0.0` truncating to 0 the way `cvttsd2si` does, and no
input where the zig arm disagrees with the x86 one.

**The blocker was the expectation, not the emitter.** #100 put NaN, infinity
and overflow rows in `codex/test/ops`, which `build/test-cross-batch.ps1`
grades on arm64 and riscv64 as well — and those three cases are exactly where
the ISAs disagree: x86 answers the integer indefinite, arm64 and riscv
saturate.

That is settled now, by you: `real-to-int-wide.codex` carries the unambiguous
range for all three backends, and says why in its own prose. **So this PR adds
no cross-graded expectation at all** — the emitter alone, and the two script
fixes the review asked for.

## Measured, transpiled and run

The plug emits `real-to-bits` and `bits-to-real` and neither of the two
conversions beside them, so a program that turns a Real into an Integer or
back refuses at the emitter. `show` on a Real routes through the same
conversion, so it is not an exotic path.

| probe | answer |
|---|---|
| `real-from-int` then `real-to-int` of `3000000000` | `3000000000` |
| the same of `-3000000000` | `-3000000000` |
| `real-to-int 2.75` | `2` |
| `real-to-int -2.75` | `-2` |

3000000000 is above 2^31 on purpose — the range a 32-bit conversion saturates
in, which is where the riscv encoder defect #100 exposed lived. Truncation is
toward zero rather than toward the floor. Only unambiguous values, the
standard `real-to-int-wide` sets.

## The two script notes from the review

`run.ps1` creates the `build-output` directory it writes its log into. Without
it a fresh checkout failed as `IR compile failed; see <that log>`, naming a
file it had just been unable to create.

And it passes `-Kernel` in **both** branches, which is the half the earlier
version got wrong: testing an absolute path and then passing nothing left
`compile.ps1` on its own relative default, so from any working directory but
the repo root the test passed and the compile failed anyway. Passing it
explicitly also puts the choice in the `kernel:` digest line. This is related
to backlog 2.26 — the same scripts sharing a fixed scratch path — and is not
that defect.

## Backlog

Row **2.29**, since 2.06 is taken on your side.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpLJYCGhn1N3qkbuSU1k6s
