### PR TITLE
COMPILER-54: fifteen foreword chapters are CRLF and cannot be read as written

### DIFF
--- a/codex/compiler/compiler-backlog.md
+++ b/codex/compiler/compiler-backlog.md
@@ -210,3 +210,43 @@ the live `utf8-to-cce` path, so peeling them is a separate change.
 as the symbol being absent from compiler source. A recursive
 `Get-ChildItem | Select-String` over the 3,948 live `.codex` files is what
 answered it.
+
+## COMPILER-54 -- CONTRIBUTED by Steve Howell (PR pending, 2026-09-06): fifteen foreword chapters are CRLF, and the compiler cannot read them as they sit on disk
+
+`codex/foreword/{ai,engine,math,signal,sim}` hold fifteen `.codex` files with
+CRLF line endings. Every other `.codex` file in the checkout is LF -- 0 of the
+remaining 3,700-odd carries a carriage return -- so these are the exception, and
+they have been since at least `53b3b213`.
+
+**A reader that keeps the bytes cannot compile them, two different ways.**
+
+    codex/foreword/math/Complex.codex     16 x CDX1000
+    codex/foreword/signal/FFT.codex       CDX3007
+
+CDX1000 because a carriage return inside a TYPE is refused. Measured one probe
+per position against `native/codexir`: an unmapped byte is skipped in an
+expression and on the lines around a definition, and halts the compile inside a
+type signature. Carriage return, tab, vertical tab, form feed and SOH all behave
+the same way there, so this is the general rule and not a rule about CRLF.
+
+CDX3007 for a different reason and it is the one that hides: a `Chapter:` header
+ending in CRLF carries the return into the chapter NAME. The chapter is present
+in the unit and `cites Signal chapter FFT` still cannot match it, because what is
+present is `FFT\r`. The unit then reports a missing chapter, which is not what is
+wrong with it.
+
+**Why this has never bitten.** Every ordinary front door normalises on read --
+PowerShell's `Get-Content` does, and so does Python's `read_text`, which is how
+our own harnesses reach the compiler. The defect is invisible from the outside
+and appears the moment anything reads the file faithfully.
+
+**The change is whitespace only, and measured to be a no-op.** CRLF becomes LF
+and a stray doubled `\r\r\n` becomes one LF. All 35 corpus programs that cite one
+of these fifteen chapters were compiled through `native/codexir` before and
+after: **35 identical IR, 0 different.** So no program changes meaning; what
+changes is that the files can be read by something that does not correct them
+first.
+
+Not seed-affecting.
+
+Reported and prepared by Claude (Anthropic), working with Steve Howell.

--- a/codex/foreword/ai/DiffusionScheduler.codex
+++ b/codex/foreword/ai/DiffusionScheduler.codex
@@ -1,4 +1,4 @@
-Chapter: DiffusionScheduler
+Chapter: DiffusionScheduler
   cites Foreword chapter MathLib
 
  Diffusion model noise scheduler. Implements DDPM and DDIM

--- a/codex/foreword/ai/Normalization.codex
+++ b/codex/foreword/ai/Normalization.codex
@@ -1,4 +1,4 @@
-Chapter: Normalization
+Chapter: Normalization
   cites Foreword chapter MathLib
   cites AI chapter Activation
   cites AI chapter Tensor

--- a/codex/foreword/engine/HairSim.codex
+++ b/codex/foreword/engine/HairSim.codex
@@ -1,4 +1,4 @@
-Chapter: HairSim
+Chapter: HairSim
   cites Foreword chapter MathLib
   cites Engine chapter SoftBody
   cites Math chapter Quaternion

--- a/codex/foreword/engine/Musculature.codex
+++ b/codex/foreword/engine/Musculature.codex
@@ -1,4 +1,4 @@
-Chapter: Musculature
+Chapter: Musculature
   cites Foreword chapter MathLib
   cites Engine chapter Skinning
   cites Engine chapter SoftBody

--- a/codex/foreword/engine/PhysicsJoint.codex
+++ b/codex/foreword/engine/PhysicsJoint.codex
@@ -1,4 +1,4 @@
-Chapter: PhysicsJoint
+Chapter: PhysicsJoint
   cites Foreword chapter MathLib
   cites Sim chapter Physics
   cites Math chapter Quaternion

--- a/codex/foreword/engine/SoftBody.codex
+++ b/codex/foreword/engine/SoftBody.codex
@@ -1,4 +1,4 @@
-Chapter: SoftBody
+Chapter: SoftBody
   cites Foreword chapter MathLib
   cites Sim chapter Physics
   cites Engine chapter PhysicsJoint

--- a/codex/foreword/math/Complex.codex
+++ b/codex/foreword/math/Complex.codex
@@ -1,4 +1,4 @@
-Chapter: Complex
+Chapter: Complex
   cites Foreword chapter MathLib
 
  Complex number arithmetic. Fixed-point (scale 1000). Supports add,

--- a/codex/foreword/math/Geodesic.codex
+++ b/codex/foreword/math/Geodesic.codex
@@ -1,4 +1,4 @@
-Chapter: Geodesic
+Chapter: Geodesic
   cites Foreword chapter MathLib
   cites Foreword chapter Units (Length, Angle)
 

--- a/codex/foreword/signal/AudioAnalysis.codex
+++ b/codex/foreword/signal/AudioAnalysis.codex
@@ -1,4 +1,4 @@
-Chapter: AudioAnalysis
+Chapter: AudioAnalysis
   cites Foreword chapter MathLib
   cites Foreword chapter Tuple
   cites Foreword chapter Units (Frequency)

--- a/codex/foreword/signal/FFT.codex
+++ b/codex/foreword/signal/FFT.codex
@@ -1,4 +1,4 @@
-Chapter: FFT
+Chapter: FFT
   cites Foreword chapter MathLib
 
  Fast Fourier Transform using fixed-point arithmetic (scale 1000).

--- a/codex/foreword/signal/Noise.codex
+++ b/codex/foreword/signal/Noise.codex
@@ -1,5 +1,5 @@
-Chapter: Noise
-  cites Foreword chapter Wrap64
+Chapter: Noise
+  cites Foreword chapter Wrap64
   cites Foreword chapter MathLib
   cites Signal chapter Perlin
   cites Foreword chapter Tuple

--- a/codex/foreword/signal/Synth.codex
+++ b/codex/foreword/signal/Synth.codex
@@ -1,4 +1,4 @@
-Chapter: Synth
+Chapter: Synth
   cites Foreword chapter MathLib
   cites Signal chapter Envelope
   cites Foreword chapter Units (Frequency)

--- a/codex/foreword/sim/Collision.codex
+++ b/codex/foreword/sim/Collision.codex
@@ -1,4 +1,4 @@
-Chapter: Collision
+Chapter: Collision
   cites Foreword chapter MathLib
 
  2D and 3D collision detection primitives. AABB, sphere, point-in-box,

--- a/codex/foreword/sim/Physics.codex
+++ b/codex/foreword/sim/Physics.codex
@@ -1,4 +1,4 @@
-Chapter: Physics
+Chapter: Physics
   cites Foreword chapter MathLib
   cites Math chapter Quaternion
   cites Foreword chapter Units (Mass)

--- a/codex/foreword/sim/Steering.codex
+++ b/codex/foreword/sim/Steering.codex
@@ -1,4 +1,4 @@
-Chapter: Steering
+Chapter: Steering
   cites Foreword chapter MathLib
   cites Math chapter Quaternion
   cites Foreword chapter Units (Speed, Force)


### PR DESCRIPTION
Fifteen `.codex` files under `codex/foreword/{ai,engine,math,signal,sim}` have CRLF line endings. Every other `.codex` file in the checkout is LF — 0 of the remaining 3,700-odd carries a carriage return — so these are the exception, and have been since at least `53b3b213`.

**A reader that keeps the bytes cannot compile them, two different ways:**

```
codex/foreword/math/Complex.codex     16 x CDX1000
codex/foreword/signal/FFT.codex       CDX3007
```

`CDX1000` because a carriage return inside a **type** is refused. Measured one probe per position against `native/codexir`: an unmapped byte is skipped in an expression and on the lines around a definition, and halts the compile inside a type signature. Carriage return, tab, vertical tab, form feed and SOH all behave identically there — so this is the general rule, not a rule about CRLF, and it is reported here as context rather than as something to change.

`CDX3007` for a different reason, and it is the one that hides: a `Chapter:` header ending in CRLF carries the return into the chapter **name**. The chapter is present in the unit and `cites Signal chapter FFT` still cannot match it, because what is present is `FFT\r`. The unit then reports a missing chapter, which is not what is wrong with it.

**Why this has never bitten.** Every ordinary front door normalises on read — PowerShell's `Get-Content` does, and so does Python's `read_text`. The defect is invisible from the outside and appears the moment something reads the files faithfully. We hit it building a byte-preserving bundler.

**The change is whitespace only, and measured to be a no-op.** CRLF becomes LF, and a stray `\r\r\n` becomes one LF. All 35 corpus programs that cite one of these fifteen chapters were compiled through `native/codexir` before and after the change: **35 identical IR, 0 different.** No program changes meaning; what changes is that the files can be read by something that does not correct them first.

Not seed-affecting. Backlog row COMPILER-54 included.

Prepared by Claude (Anthropic), working with Steve Howell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpLJYCGhn1N3qkbuSU1k6s