### PR TITLE
zig plug: an unused let binds and silences its value, never discards a name

### DIFF
--- a/codex/plugs/zig/ZigEmitter.codex
+++ b/codex/plugs/zig/ZigEmitter.codex
@@ -1657,7 +1657,7 @@ Section: Expression Emission
     is IrLet (name) (ty) (val) (body) (sp) ->
      if zig-is-seq-name name then zig-label d & ": { _ = " & emit-zig-expr val ctx (d + 1) & "; break :" & zig-label d & " " & emit-zig-expr body ctx (d + 1) & "; }"
      else if zig-occurs body name then zig-label d & ": { const " & zig-bind-name ctx name d & zig-let-annot ty & " = " & emit-zig-expr val ctx (d + 1) & "; break :" & zig-label d & " " & emit-zig-expr body (zig-bind-push ctx name d) (d + 1) & "; }"
-     else zig-label d & ": { _ = " & emit-zig-expr val ctx (d + 1) & "; break :" & zig-label d & " " & emit-zig-expr body ctx (d + 1) & "; }"
+     else zig-label d & ": { const " & zig-bind-name ctx name d & zig-let-annot ty & " = " & emit-zig-expr val ctx (d + 1) & "; _ = " & zig-bind-name ctx name d & "; break :" & zig-label d & " " & emit-zig-expr body (zig-bind-push ctx name d) (d + 1) & "; }"
     is IrApply (f) (a) (ty) (sp) -> emit-zig-apply e ctx d
     is IrLambda (params) (body) (ty) (sp) -> zig-lambda-closure params body ty ctx d
     is IrList (elems) (ty) (sp) -> emit-zig-list elems ty ctx d

--- a/codex/test/ops/unused-let-alias-discard.codex
+++ b/codex/test/ops/unused-let-alias-discard.codex
@@ -1,0 +1,31 @@
+Chapter: Unused Let Alias Discard
+
+ An unused `let` bound to a NAME that is read elsewhere must not reach the zig
+ plug as `_ = x`: zig refuses that as a pointless discard of a used local. The
+ emitter binds the value to the silenced local rather than discarding it, so
+ the name stays used and the fresh binding is what gets discarded.
+
+ Two shapes: the alias is read in the CONTINUATION, and the alias is read only
+ in an ENCLOSING sibling binding the body never names.
+
+Section: Functions
+
+  reads-in-body : Integer -> Integer
+  reads-in-body (n) =
+   let xs = [10, 20, 30]
+   in let unused = xs
+   in list-at xs 0 + list-at xs 1 + list-at xs 2
+
+  reads-in-sibling : Integer -> Integer
+  reads-in-sibling (n) =
+   let xs = [40, 50]
+   in let a = xs
+   in let unused = xs
+   in list-at a 1
+
+Section: Entry
+
+  opening : [Console] Nothing = act
+   print-line-uni ("reads-in-body: " & show (reads-in-body 0))
+   print-line-uni ("reads-in-sibling: " & show (reads-in-sibling 0))
+  end

--- a/codex/test/ops/unused-let-alias-discard.expected
+++ b/codex/test/ops/unused-let-alias-discard.expected
@@ -1,0 +1,2 @@
+reads-in-body: 60
+reads-in-sibling: 50


### PR DESCRIPTION
## The bug

The zig plug refuses to build a program with an **unused `let` bound to a name that is read elsewhere**. The emitter sequences an unused binding's value with `_ = <val>;`; when the value is a bare name `x`, that becomes `_ = x;`, and zig 0.16 rejects it — *"pointless discard of local constant"* — because `x` is already used. The program is well-typed and runs correctly on the interpreter and the wasm plug; only the zig plug refuses it.

Minimal shapes (both in the added test):

```
let xs = [10, 20, 30] in let unused = xs in list-at xs 0 + list-at xs 1 + list-at xs 2   -- alias read in the body
let xs = [40, 50] in let a = xs in let unused = xs in list-at a 1                        -- alias read in an enclosing sibling
```

## The fix

One line in `codex/plugs/zig/ZigEmitter.codex`. An unused `let` now **binds its value to the (silenced) local** rather than discarding the value directly:

```
_ = <val>;                    ->    const b = <val>; _ = b;
```

The value is *read into the const*, so a name is used rather than pointlessly discarded; the fresh local, read only by its own `_ = b`, is what zig silences. It evaluates the value exactly as the discard did, so **no program's output changes**, and it needs no whole-definition scope analysis — every unused `let` is handled the same way, names and expressions alike. (Deciding "is this name read elsewhere" needs whole-definition scope and is easy to get subtly wrong; binding-and-silencing sidesteps that entirely.)

## Measurement

- **Fixed point HOLDS** — a `codexzig` built from this change transpiles its own source byte-identically under QEMU and as the native binary; `arith` matches its expected output.
- Curated program set (28) and the safari application's zig arm: **green**.
- The 29 programs hand-ported from roc-lang/roc's `eval_closure_recursion_tests` — several of which hit this exact discard — now all build and reproduce their expected output through the plug.
- Added `codex/test/ops/unused-let-alias-discard` (two shapes) to pin it.

Found by the roc-lang port corpus. This is the zig plug, which we maintain; risks are limited to zig codegen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YMgqDFdVkFRPR6auf3zfTT
