### PR TITLE
lower-record: a field's expectation carries the record's applied arguments

### DIFF
--- a/codex/compiler/IR/Lowering.codex
+++ b/codex/compiler/IR/Lowering.codex
@@ -1460,7 +1460,8 @@ Section: Collections and Act
    in let actual-ty = when record-ty
       is ErrorTy | NoExpectTy -> ty
       is otherwise -> record-ty
-   in let lowered-fields = lower-record-fields-typed fields actual-ty ctx 0 (list-length fields)
+   in let applied-ty = prefer-applied-record-ty (expected-or-recorded-ty ty ctx sp) actual-ty (ctx.local-type-vars)
+   in let lowered-fields = lower-record-fields-typed fields actual-ty applied-ty ctx 0 (list-length fields)
    in let refined-actual = refine-record-ty-from-fields actual-ty lowered-fields ctx 0 (list-length lowered-fields)
    in let emit-ty = prefer-applied-record-ty ty refined-actual (ctx.local-type-vars)
    in deck-record (IrRecord (name.value) lowered-fields emit-ty sp)
@@ -1512,18 +1513,26 @@ Section: Collections and Act
    else if list-at xs i == target then True
    else list-contains-int-loop xs target (i + 1) len
 
-  lower-record-fields-typed : List AFieldExpr, CodexType, LowerCtx, Integer, Integer -> List IRFieldVal
-  lower-record-fields-typed (fields) (record-ty) (ctx) (i) (len) =
-   lower-record-fields-acc fields record-ty ctx i len []
+ A field's expectation is its declared type with the record's APPLIED
+ arguments substituted for the declaration's parameters. `record-ty` is the
+ constructor's own form, whose field types name the declaration's variables;
+ `applied-ty` is the same record at the arguments the context supplies, or
+ at the arguments the checker recorded for the literal when the context
+ supplies none. With no applied arguments the two are one type and the
+ substitution is the identity.
 
-  lower-record-fields-acc : List AFieldExpr, CodexType, LowerCtx, Integer, Integer, List IRFieldVal -> List IRFieldVal
-  lower-record-fields-acc (fields) (record-ty) (ctx) (i) (len) (acc) =
+  lower-record-fields-typed : List AFieldExpr, CodexType, CodexType, LowerCtx, Integer, Integer -> List IRFieldVal
+  lower-record-fields-typed (fields) (record-ty) (applied-ty) (ctx) (i) (len) =
+   lower-record-fields-acc fields record-ty applied-ty ctx i len []
+
+  lower-record-fields-acc : List AFieldExpr, CodexType, CodexType, LowerCtx, Integer, Integer, List IRFieldVal -> List IRFieldVal
+  lower-record-fields-acc (fields) (record-ty) (applied-ty) (ctx) (i) (len) (acc) =
    if i == len then acc
    else let f = list-at fields i
    in let field-expected = when record-ty
-       is RecordTy (rname) (rargs) (rfields) -> lookup-record-field rfields (f.name.value)
+       is RecordTy (rname) (rargs) (rfields) -> subst-type-vars-from-arg record-ty applied-ty (lookup-record-field rfields (f.name.value))
        is otherwise -> ErrorTy
-   in lower-record-fields-acc fields record-ty ctx (i + 1) len (list-push acc (deck-record (IRFieldVal {
+   in lower-record-fields-acc fields record-ty applied-ty ctx (i + 1) len (list-push acc (deck-record (IRFieldVal {
     name = f.name.value,
     value = lower-expr (f.value) field-expected ctx,
     span = f.span

--- a/codex/test/ops/record-closure-field-poly.codex
+++ b/codex/test/ops/record-closure-field-poly.codex
@@ -1,0 +1,37 @@
+Chapter: RecordClosureFieldPoly
+
+ A polymorphic record whose field is a closure, built inside a polymorphic
+ definition. The closure's emitted type names the definition's own variable,
+ not the record declaration's parameter, whether the literal is returned
+ directly or bound by a `let` first.
+
+   wrap       the closure returns the captured value
+   wrap-let   the same literal, bound by a `let` before it is returned
+   wrap-map   the closure applies a captured function to another box's closure
+
+Section: Types
+
+  Box (a) = record {
+   get : Integer -> a
+  }
+
+Section: Functions
+
+  wrap : b -> Box b
+  wrap (x) = Box { get = \i -> x }
+
+  wrap-let : b -> Box b
+  wrap-let (x) = let bx = Box { get = \i -> x } in bx
+
+  wrap-map : Box a, (a -> b) -> Box b
+  wrap-map (bx) (f) = Box { get = \i -> f ((bx.get) i) }
+
+Section: Entry
+
+  opening : [Console] Nothing
+  opening = act
+   print-line-uni ("wrap " & show (((wrap 21).get) 0))
+   print-line-uni ("wrap-let " & show (((wrap-let 8).get) 0))
+   print-line-uni ("wrap-map " & show (((wrap-map (wrap 21) (\n -> n * 2)).get) 0))
+   print-line-uni ("wrap-text " & ((wrap-map (wrap 7) (\n -> "seven")).get) 0)
+  end

--- a/codex/test/ops/record-closure-field-poly.expected
+++ b/codex/test/ops/record-closure-field-poly.expected
@@ -1,0 +1,4 @@
+wrap 21
+wrap-let 8
+wrap-map 42
+wrap-text seven


### PR DESCRIPTION
*Written by Claude, working with Steve Howell, on his account and at his direction.*

## The defect

`lower-record-fields-acc` hands each field value the field's **declared** type as its expectation. For `Box (a) = record { get : Integer -> a }` that is `Integer -> a`, with the *declaration's* parameter in it. `lower-lambda` records that expectation when the body's type still carries variables, so a closure built inside a polymorphic definition reaches the wire naming a variable nothing in that definition binds:

```
  wrap : b -> Box b
  wrap (x) = Box { get = \i -> x }
```

At `49fa9f27` the lifted closure is `(def "__lam_0" ... (fn (tvar 3) (fn int-default (tvar 2))) ...)` — `3` is `wrap`'s `b`, `2` is `Box`'s `a`. The zig plug refuses it: `unresolved type variable T2 of __lam_0`. The interpreter, which erases types, prints the right answer. A monomorphic use (`wrap-int : Integer -> Box Integer`) was already clean, because a body with no variables lets `lambda-recorded-ty` substitute the declaration's parameter away; only a polymorphic body kept it.

Found by three programs we ported from the Roc language's test suite, each building an iterator record whose `next` field is a closure inside `iter-map : Iter a, (a -> b) -> Iter b`; all three failed the zig plug on exactly this variable.

## The fix

The expectation is now the declared field type with the record's **applied** arguments substituted for the declaration's parameters. `prefer-applied-record-ty`, which `lower-record` computes for the record's own emitted type after the fields, is now also computed on the unrefined type before them: from the context's expectation, or, when the context supplies none (a `let` binding the literal, say), from the type the checker recorded for the literal, through `expected-or-recorded-ty`. `subst-type-vars-from-arg record-ty applied-ty` maps each parameter to its argument. A record declared without parameters, or a literal for which neither the context nor the checker supplies arguments, gets the expectation it always did; the census below reports every other case.

After the fix the closure is `(fn (tvar 3) (fn int-default (tvar 3)))` — the definition's own `b` — and the plug builds it. `IR/Lowering.codex` only: `lower-record`, `lower-record-fields-typed`, `lower-record-fields-acc`.

## Pinned by a test unit

`codex/test/ops/record-closure-field-poly`: two closure-building definitions over a polymorphic box, one of them binding the literal with a `let` before returning it, at three instantiations. The zig plug refuses the unit before and prints its `.expected` after; the interpreter prints it either way. No `ir-fidelity` case: that instrument flags a name carrying two types, and `x` here carries one.

## Measurement

Stack: our `u58-candidate` = Update 57 `49fa9f27` + PR 135 + PR 138 + PR 139 + this commit; the PR branch itself is off clean `49fa9f27` and is independent of PR 139 (different definitions in the same file). Bare metal is not measured here beyond the fixed point.

- **Self-host, no guest** (`bootstrap_native.py`): converged in ONE round — the predecessor and the rebuilt `codexzig` emit byte-identical zig for the compiler's own source. The compiler contains no polymorphic record literal with a polymorphic closure field.
- **Fixed point under QEMU** (`build.py --force`): **HOLDS, byte-identical** (`build.py --force` on the same stack, 495 s, three guests; `arith` matches all 9 lines).
- **Corpus census, hosted `codexir` before vs after, the 1,269 programs under `codex/test` at Update 57 (apps excluded), each resolved into one file:** **1,046 identical, 6 differ**, 217 refused by both (the same 217). The six are all this shape: `queue-test` (an empty-list field of `Queue a` takes the definition's variable instead of the declaration's), the three Roc iterator ports (the closure field above), and `typeclass-poly` / `typeclass-smoke`, whose class-dictionary records are polymorphic record literals with lambda fields -- the `Showable-dict-Integer carries (args (tvar 511))` lead recorded under COMPILER-30 is this defect; `typeclass-poly`'s dictionary now carries `int-default` where it carried `(tvar 16)`.
- **Three corpora we grade by output** (28 programs cut from `codex/test`, 29 ported from Roc's test suite, 54 specs of safari, a 54-chapter application of ours), hosted `codexir` before vs after: exactly three programs move, the three Roc iterator ports, and each moves to the IR that a second front end we maintain, written independently in Rust, already emitted for it, byte for byte.
- **Zig plug arm** through the rebuilt `codexzig`: the Roc ports 25 → 28 of 29 (the one left is COMPILER-74's `roc-alias-empty`); the 28 curated programs 28 of 28 and safari 51 of 54, unchanged (safari's three are Real literals one ULP apart, issue 125).

Risks: this is `IR/Lowering.codex`, core compiler; measured on the hosted arms above. The change alters the expectation handed to a field value only when the context or the checker supplies type arguments for the literal, and the census says how often that changes a byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012VqZFAQ561bYhSJ3gBoC3P
