### PR TITLE
zig and wasm plugs: a nested sub-pattern is a test, not a wildcard

### DIFF
--- a/codex/plugs/wasm/WasmEmitter.codex
+++ b/codex/plugs/wasm/WasmEmitter.codex
@@ -1317,24 +1317,27 @@ Section: Expression Emission
   emit-wat-ctor-pat (ctx) (name) (subs) (guard) (body) (branches) (i) (depth) =
    let tag = find-ctor-in-typedefs (ctx.type-defs) name 0
    in let bind-subs = emit-wat-bind-ctor-subs ctx subs 0
-   in if (i == list-length branches - 1) & wat-guard-trivial guard & (wat-ctor-has-lit-subs subs 0 == False) then
+   in if (i == list-length branches - 1) & wat-guard-trivial guard & (wat-ctor-has-test-subs subs 0 == False) then
     emit-wat-arm-block "" "(i32.const 1)" bind-subs (emit-wat-expr ctx body)
    else emit-wat-arm-block "" (wat-ctor-arm-cond ctx tag subs guard bind-subs) bind-subs (emit-wat-expr ctx body)
 
- A LITERAL inside a constructor pattern is a TEST, not a binding, and
- `emit-wat-bind-ctor-subs` had no arm for one: it bound a variable sub-pattern
- and sent everything else to `is otherwise`, so `BInt (0)` matched every `BInt`
- and every arm answered the first one's body. The tests fold onto the tag test
- rather than beside it, because a payload load on an object of the wrong tag can
- address past the object and trap, which is the reason the guard is already
- gated this way.
+ A sub-pattern of a constructor pattern is a binding (a variable), nothing
+ (a wildcard), or a TEST: a literal is an equality on the payload field, and
+ a constructor is an equality on the tag of the object the field points at,
+ followed by that constructor's own sub-patterns through that object. Every
+ test and every binding under a tag test sits INSIDE it, because a payload
+ load on an object of the wrong tag can address past the object and trap.
+ `wat-ctor-sub-tests-at` and `emit-wat-bind-ctor-subs-at` take the object's
+ address as an expression; the scrutinee's forms are the ones at
+ `(local.get scrut)`.
 
-  wat-ctor-has-lit-subs : List IRPat, Integer -> Boolean
-  wat-ctor-has-lit-subs (subs) (i) =
+  wat-ctor-has-test-subs : List IRPat, Integer -> Boolean
+  wat-ctor-has-test-subs (subs) (i) =
    if i >= list-length subs then False
    else when list-at subs i
     is IrLitPat (t) (ty) (sp) -> True
-    is otherwise -> wat-ctor-has-lit-subs subs (i + 1)
+    is IrCtorPat (n) (ss) (ty) (sp) -> True
+    is otherwise -> wat-ctor-has-test-subs subs (i + 1)
 
   wat-and-tests : Text, Text -> Text
   wat-and-tests (acc) (t) =
@@ -1342,15 +1345,28 @@ Section: Expression Emission
 
   wat-ctor-sub-tests : WasmCtx, List IRPat, Integer, Text -> Text
   wat-ctor-sub-tests (ctx) (subs) (i) (acc) =
+   wat-ctor-sub-tests-at ctx subs i acc ("(local.get " & wat-scrut ctx & ")")
+
+  wat-ctor-sub-tests-at : WasmCtx, List IRPat, Integer, Text, Text -> Text
+  wat-ctor-sub-tests-at (ctx) (subs) (i) (acc) (base) =
    if i >= list-length subs then acc
-   else let fld = "(i64.load (i32.add (i32.wrap_i64 (local.get " & wat-scrut ctx & ")) (i32.const " & integer-to-text (8 + i * 8) & ")))"
+   else let fld = "(i64.load (i32.add (i32.wrap_i64 " & base & ") (i32.const " & integer-to-text (8 + i * 8) & ")))"
    in when list-at subs i
+    is IrCtorPat (n) (ss) (ty) (sp) ->
+     let tag = find-ctor-in-typedefs (ctx.type-defs) n 0
+     in let tag-test = "(i64.eq (i64.load (i32.wrap_i64 " & fld & ")) (i64.const " & integer-to-text tag & "))"
+     in let binds = emit-wat-bind-ctor-subs-at ctx ss 0 fld
+     in let inner = wat-ctor-sub-tests-at ctx ss 0 "" fld
+     in let under = if text-length inner == 0 then "(i32.const 1)" else inner
+     in let whole = if (text-length inner == 0) & (text-length binds == 0) then tag-test
+        else "(if (result i32) " & tag-test & " (then " & binds & under & ") (else (i32.const 0)))"
+     in wat-ctor-sub-tests-at ctx subs (i + 1) (wat-and-tests acc whole) base
     is IrLitPat (t) (ty) (sp) ->
-     wat-ctor-sub-tests ctx subs (i + 1) (wat-and-tests acc
+     wat-ctor-sub-tests-at ctx subs (i + 1) (wat-and-tests acc
       (if wat-is-text-type ty
        then "(i32.wrap_i64 (call $text_eq " & fld & " " & wat-strtab-ref (ctx.strings) t & "))"
-       else "(i64.eq " & fld & " (i64.const " & wat-lit-pat-const t & "))"))
-    is otherwise -> wat-ctor-sub-tests ctx subs (i + 1) acc
+       else "(i64.eq " & fld & " (i64.const " & wat-lit-pat-const t & "))")) base
+    is otherwise -> wat-ctor-sub-tests-at ctx subs (i + 1) acc base
 
   wat-ctor-arm-cond : WasmCtx, Integer, List IRPat, IRExpr, Text -> Text
   wat-ctor-arm-cond (ctx) (tag) (subs) (guard) (bind-subs) =
@@ -1363,14 +1379,18 @@ Section: Expression Emission
 
   emit-wat-bind-ctor-subs : WasmCtx, List IRPat, Integer -> Text
   emit-wat-bind-ctor-subs (ctx) (subs) (i) =
+   emit-wat-bind-ctor-subs-at ctx subs i ("(local.get " & wat-scrut ctx & ")")
+
+  emit-wat-bind-ctor-subs-at : WasmCtx, List IRPat, Integer, Text -> Text
+  emit-wat-bind-ctor-subs-at (ctx) (subs) (i) (base) =
    if i >= list-length subs then ""
-   else let off = 8 + i * 8
+   else let fld = "(i64.load (i32.add (i32.wrap_i64 " & base & ") (i32.const " & integer-to-text (8 + i * 8) & ")))"
    in let sub = list-at subs i
    in (when sub
-    is IrVarPat (name) (ty) (sp) -> "(local.set $" & wat-sanitize name & " (i64.load (i32.add (i32.wrap_i64 (local.get " & wat-scrut ctx & ")) (i32.const " & integer-to-text off & ")))) "
+    is IrVarPat (name) (ty) (sp) -> "(local.set $" & wat-sanitize name & " " & fld & ") "
     is IrWildPat (sp) -> ""
     is IrVecPat (pats) (ty) (sp) -> ""
-    is otherwise -> "") & emit-wat-bind-ctor-subs ctx subs (i + 1)
+    is otherwise -> "") & emit-wat-bind-ctor-subs-at ctx subs (i + 1) base
 
   emit-wat-act : WasmCtx, List IRActStmt -> Text
   emit-wat-act (ctx) (stmts) =
@@ -2150,7 +2170,7 @@ Section: Tail Call Optimization
   emit-wat-ctor-arm-tco (ctx) (name) (subs) (guard) (body) (bs) (i) =
    let tag = find-ctor-in-typedefs (ctx.type-defs) name 0
    in let bind-subs = emit-wat-bind-ctor-subs ctx subs 0
-   in if (i == list-length bs - 1) & wat-guard-trivial guard & (wat-ctor-has-lit-subs subs 0 == False) then
+   in if (i == list-length bs - 1) & wat-guard-trivial guard & (wat-ctor-has-test-subs subs 0 == False) then
     emit-wat-arm-block "" "(i32.const 1)" bind-subs body
    else emit-wat-arm-block "" (wat-ctor-arm-cond ctx tag subs guard bind-subs) bind-subs body
 

--- a/codex/plugs/zig/ZigEmitter.codex
+++ b/codex/plugs/zig/ZigEmitter.codex
@@ -2115,7 +2115,7 @@ Section: Match Emission
    let mty = if text-length (zig-ll-elem-opt mty0 (ctx.scope-tvars)) > 0 then mty0
       else zig-arms-list-type branches 0 mty0 (ctx.scope-tvars)
    in let ex = zig-match-exhaustive ctx (zig-expr-type scrut) branches
-   in if zig-branches-guarded branches 0 then emit-zig-match-chain scrut branches ctx d mty
+   in if zig-branches-guarded branches 0 | zig-branches-nested branches 0 then emit-zig-match-chain scrut branches ctx d mty
    else zig-pin-lit-arms branches 0 ("switch (" & emit-zig-expr scrut ctx (d + 1) & zig-match-deref ctx (zig-expr-type scrut) & ") { " & emit-zig-match-arms branches 0 ctx d ex mty tl & " }")
 
  A zig `switch` prong refuses a value an earlier prong already names:
@@ -2330,11 +2330,12 @@ Section: Match Emission
   emit-zig-chain-arm : IRPat, IRExpr, IRExpr, ZigCtx, Integer, CodexType, Text -> Text
   emit-zig-chain-arm (pat) (guard) (body) (ctx) (d) (mty) (sv) =
    when pat
-    is IrLitPat (text) (ty) (sp) -> "if (" & sv & " == " & zig-lit-pat-text text ty & ") { " & emit-zig-chain-tail guard body ctx d mty & "} "
+    is IrLitPat (text) (ty) (sp) -> "if (" & zig-chain-lit-test sv text ty & ") { " & emit-zig-chain-tail guard body ctx d mty & "} "
     is IrCtorPat (name) (subs) (ty) (sp) ->
      let nsubs = list-length subs
      in let test = "if (" & sv & " == ." & zig-sanitize name & ") { "
-     in if nsubs == 0 then test & emit-zig-chain-tail guard body ctx d mty & "} "
+     in if zig-subs-nested subs 0 then emit-zig-chain-nested pat sv guard body ctx d mty
+     else if nsubs == 0 then test & emit-zig-chain-tail guard body ctx d mty & "} "
      else if nsubs == 1 then
       let binder = zig-pat-binder (list-at subs 0) 0
       in if (binder == "_") | (zig-occurs-either body guard binder == False)
@@ -2349,6 +2350,105 @@ Section: Match Emission
      else "{ " & emit-zig-chain-tail guard body ctx d mty & "} "
     is IrWildPat (sp) -> "{ " & emit-zig-chain-tail guard body ctx d mty & "} "
     is IrVecPat (pats) (ty) (sp) -> "@compileError(\"zig plug: vector patterns not supported\"); "
+
+ A constructor pattern with a constructor or a literal INSIDE it is a
+ conjunction of tests, one per level, and only the chain form can express
+ it; a Text literal pattern at any level is a `cx_text_eq` test, which a
+ switch prong on a slice cannot spell, so it takes the chain form too: each inner test is an `if` inside the enclosing one, so a failed inner
+ test falls out of the arm to the next one, where a switch prong could not
+ fall through and two prongs on one constructor are a duplicate. The
+ sub-patterns are walked as a WORK LIST of (pattern, value) pairs: a
+ constructor sub-pattern replaces itself with its own sub-patterns at the
+ head of the list, each addressed through the constructor's payload (with
+ `.*` when the field's type is boxed), and the arm's tail is emitted once,
+ when the list is empty. A variable sub-pattern binds its value only if the
+ body or the guard reads it, because zig refuses an unused local; a Text
+ literal compares through `cx_text_eq`, because a slice has no `==`.
+
+  zig-pat-nested : IRPat -> Boolean
+  zig-pat-nested (p) =
+   when p
+    is IrCtorPat (name) (subs) (ty) (sp) -> zig-subs-nested subs 0
+    is IrLitPat (text) (ty) (sp) -> zig-is-text-ty ty
+    is otherwise -> False
+
+  zig-is-text-ty : CodexType -> Boolean
+  zig-is-text-ty (ty) =
+   when ty
+    is TextTy -> True
+    is otherwise -> False
+
+  zig-subs-nested : List IRPat, Integer -> Boolean
+  zig-subs-nested (subs) (i) =
+   if i >= list-length subs then False
+   else let nested = when list-at subs i
+     is IrCtorPat (name) (ss) (ty) (sp) -> True
+     is IrLitPat (text) (ty) (sp) -> True
+     is otherwise -> False
+   in nested | zig-subs-nested subs (i + 1)
+
+  zig-branches-nested : List IRBranch, Integer -> Boolean
+  zig-branches-nested (bs) (i) =
+   if i >= list-length bs then False
+   else zig-pat-nested ((list-at bs i).pattern) | zig-branches-nested bs (i + 1)
+
+  zig-chain-lit-test : Text, Text, CodexType -> Text
+  zig-chain-lit-test (sv) (text) (ty) =
+   when ty
+    is TextTy -> "cx_text_eq(" & sv & ", \"" & zig-escape-text text & "\")"
+    is otherwise -> sv & " == " & zig-lit-pat-text text ty
+
+  zig-deep-binders : IRPat, List Text -> List Text
+  zig-deep-binders (p) (acc) =
+   when p
+    is IrVarPat (name) (ty) (sp) -> list-push acc name
+    is IrCtorPat (name) (subs) (ty) (sp) -> zig-deep-binders-list subs 0 acc
+    is otherwise -> acc
+
+  zig-deep-binders-list : List IRPat, Integer, List Text -> List Text
+  zig-deep-binders-list (subs) (i) (acc) =
+   if i >= list-length subs then acc
+   else zig-deep-binders-list subs (i + 1) (zig-deep-binders (list-at subs i) acc)
+
+  zig-push-bound-names : ZigCtx, List Text, Integer, Integer -> ZigCtx
+  zig-push-bound-names (ctx) (names) (i) (d) =
+   if i >= list-length names then ctx
+   else zig-push-bound-names (zig-bind-push ctx (list-at names i) d) names (i + 1) d
+
+  zig-sub-values : ZigCtx, List IRPat, Integer, Text, List Text -> List Text
+  zig-sub-values (ctx) (subs) (i) (payload) (acc) =
+   if i >= list-length subs then acc
+   else let raw = if list-length subs == 1 then payload else payload & "[" & integer-to-text i & "]"
+   in let sv = when list-at subs i
+     is IrCtorPat (name) (ss) (ty) (sp) -> raw & zig-match-deref ctx ty
+     is otherwise -> raw
+   in zig-sub-values ctx subs (i + 1) payload (list-push acc sv)
+
+  zig-list-from : List a, Integer, List a -> List a
+  zig-list-from (xs) (i) (acc) =
+   if i >= list-length xs then acc else zig-list-from xs (i + 1) (list-push acc (list-at xs i))
+
+  emit-zig-chain-nested : IRPat, Text, IRExpr, IRExpr, ZigCtx, Integer, CodexType -> Text
+  emit-zig-chain-nested (pat) (sv) (guard) (body) (ctx) (d) (mty) =
+   let tail-ctx = zig-push-bound-names ctx (zig-deep-binders pat []) 0 d
+   in emit-zig-chain-work [pat] [sv] 0 guard body ctx tail-ctx d mty
+
+  emit-zig-chain-work : List IRPat, List Text, Integer, IRExpr, IRExpr, ZigCtx, ZigCtx, Integer, CodexType -> Text
+  emit-zig-chain-work (pats) (svs) (i) (guard) (body) (ctx) (tail-ctx) (d) (mty) =
+   if i >= list-length pats then emit-zig-chain-tail guard body tail-ctx d mty
+   else let sv = list-at svs i
+   in when list-at pats i
+    is IrCtorPat (name) (subs) (ty) (sp) ->
+     let inner-pats = zig-list-from pats (i + 1) (zig-list-from subs 0 [])
+     in let inner-svs = zig-list-from svs (i + 1) (zig-sub-values ctx subs 0 (sv & "." & zig-sanitize name) [])
+     in "if (" & sv & " == ." & zig-sanitize name & ") { " & emit-zig-chain-work inner-pats inner-svs 0 guard body ctx tail-ctx d mty & "} "
+    is IrLitPat (text) (ty) (sp) ->
+     "if (" & zig-chain-lit-test sv text ty & ") { " & emit-zig-chain-work pats svs (i + 1) guard body ctx tail-ctx d mty & "} "
+    is IrVarPat (name) (ty) (sp) ->
+     let bind = if zig-occurs-either body guard name then "const " & zig-bind-name ctx name d & " = " & sv & "; " else ""
+     in bind & emit-zig-chain-work pats svs (i + 1) guard body ctx tail-ctx d mty
+    is IrWildPat (sp) -> emit-zig-chain-work pats svs (i + 1) guard body ctx tail-ctx d mty
+    is IrVecPat (ps) (ty) (sp) -> "@compileError(\"zig plug: vector patterns not supported\"); "
 
   zig-any-sub-occurs-g : List IRPat, Integer, IRExpr, IRExpr -> Boolean
   zig-any-sub-occurs-g (subs) (i) (body) (guard) =

--- a/codex/test/ops/match-nested-pattern.codex
+++ b/codex/test/ops/match-nested-pattern.codex
@@ -1,0 +1,102 @@
+Chapter: MatchNestedPattern
+
+ A constructor pattern with a constructor or a literal inside it is a
+ conjunction of tests, one per level; a failed inner test falls through to
+ the next arm. The shapes: a payload binding two and three constructors
+ deep, a multi-payload constructor inside another, an Integer and a Text
+ literal inside a constructor, a Text literal on its own, and nested nullary
+ constructors.
+
+Section: Types
+
+  Res (a) (e) =
+   | Ok (a)
+   | Err (e)
+
+  Pair =
+   | Two (Integer) (Integer)
+   | One (Integer)
+
+  Logic =
+   | LTrue
+   | LFalse
+   | And (Logic) (Logic)
+   | Or (Logic) (Logic)
+   | Not (Logic)
+
+Section: Functions
+
+  describe : Res (Res Integer Text) Integer -> Integer
+  describe (v) =
+   when v
+    is Ok (Ok (n)) -> n
+    is Ok (Err (t)) -> 0 - text-length t
+    is Err (code) -> code * 10
+
+  deep : Res (Res (Res Integer Integer) Integer) Integer -> Integer
+  deep (v) =
+   when v
+    is Ok (Ok (Ok (n))) -> n
+    is Ok (Ok (Err (m))) -> m * 2
+    is Ok (Err (k)) -> k * 3
+    is Err (j) -> j * 4
+
+  pairs : Res Pair Integer -> Integer
+  pairs (v) =
+   when v
+    is Ok (Two (a) (b)) -> a * 100 + b
+    is Ok (One (a)) -> a
+    is Err (e) -> 0 - e
+
+  lit : Res Integer Integer -> Text
+  lit (v) =
+   when v
+    is Ok (0) -> "zero"
+    is Ok (n) -> "some " & show n
+    is Err (e) -> "err"
+
+  greet : Text -> Text
+  greet (t) =
+   when t
+    is "hi" -> "greeting"
+    is otherwise -> "word " & t
+
+  word : Res Text Integer -> Text
+  word (v) =
+   when v
+    is Ok ("hi") -> "greeting"
+    is Ok (t) -> "word " & t
+    is Err (e) -> "err"
+
+  shape : Logic -> Text
+  shape (v) =
+   when v
+    is And (Or (LTrue) (LFalse)) (Not (LFalse)) -> "ok"
+    is And (a) (Not (LTrue)) -> "not-true"
+    is otherwise -> "bad"
+
+Section: Entry
+
+  opening : [Console] Nothing
+  opening = act
+   print-line-uni (show (describe (Ok (Ok 7))))
+   print-line-uni (show (describe (Ok (Err "xyz"))))
+   print-line-uni (show (describe (Err 4)))
+   print-line-uni (show (deep (Ok (Ok (Ok 1)))))
+   print-line-uni (show (deep (Ok (Ok (Err 2)))))
+   print-line-uni (show (deep (Ok (Err 3))))
+   print-line-uni (show (deep (Err 4)))
+   print-line-uni (show (pairs (Ok (Two 3 4))))
+   print-line-uni (show (pairs (Ok (One 9))))
+   print-line-uni (show (pairs (Err 5)))
+   print-line-uni (lit (Ok 0))
+   print-line-uni (lit (Ok 3))
+   print-line-uni (lit (Err 1))
+   print-line-uni (greet "hi")
+   print-line-uni (greet "yo")
+   print-line-uni (word (Ok "hi"))
+   print-line-uni (word (Ok "yo"))
+   print-line-uni (shape (And (Or LTrue LFalse) (Not LFalse)))
+   print-line-uni (shape (And (Or LTrue LTrue) (Not LFalse)))
+   print-line-uni (shape (And LTrue (Not LTrue)))
+  end

--- a/codex/test/ops/match-nested-pattern.expected
+++ b/codex/test/ops/match-nested-pattern.expected
@@ -1,0 +1,20 @@
+7
+-3
+40
+1
+4
+9
+16
+304
+9
+-5
+zero
+some 3
+err
+greeting
+word yo
+greeting
+word yo
+ok
+bad
+not-true


### PR DESCRIPTION
*Written by Claude, working with Steve Howell, on his account and at his direction.*

## The defect

Both hosted plugs read a constructor or literal pattern **inside** a constructor pattern as `_`, and the zig plug cannot match a Text literal at any level. Two programs (the two Roc ports that found this), both with IR that `codexir` at `49fa9f27` and the Rust reference compiler we maintain emit byte-identically, and that the interpreter answers correctly:

```
  Logic = | LTrue | LFalse | And (Logic) (Logic) | Or (Logic) (Logic) | Not (Logic)

  shape-check (v) =
   when v
    is And (Or (LTrue) (LFalse)) (Not (LFalse)) -> "ok"
    is otherwise -> "bad"

  shape-check (And (Or LTrue LTrue) (Not LFalse))   -- interpreter: bad    zig plug: ok    wasm plug: ok
```

```
  Res (a) (e) = | Ok (a) | Err (e)

  describe : Res (Res Integer Text) Integer -> Integer
  describe (v) =
   when v
    is Ok (Ok (n)) -> n
    is Ok (Err (ignored)) -> 0 - 1
    is Err (code) -> code * 10

  describe (Ok (Ok 7)), describe (Ok (Err "x")), describe (Err 4)
      interpreter: 7, -1, 40      wasm plug: 0, 0, 40      zig plug: refuses
```

The zig plug emitted, for `describe`, two bare `.Ok` prongs with `n` never bound:

```
return switch (v_) { .Ok => @compileError("zig plug: no emitter for n"), .Ok => (0 - 1), .Err => |code_| (code_ * 10),  };
```

In `ZigEmitter.codex`, `zig-pat-binder` answers `_` for any sub-pattern that is not a variable, and every path through `emit-zig-match-arm` and `emit-zig-chain-arm` reads a sub-pattern only through it. Separately, `zig-lit-pat-text` spells a Text literal pattern bare, so `is "hi" ->` at the top of an arm emits `hi` and does not build. In `WasmEmitter.codex`, `wat-ctor-sub-tests` tests a literal sub-pattern and sends a constructor sub-pattern to `is otherwise`; `emit-wat-bind-ctor-subs` binds nothing inside one. The first program is the silent case: a nested nullary constructor is a wrong answer with no diagnostic anywhere.

Found by two programs ported from the Roc language's test suite, in a corpus of 46 such ports we run on every backend. Neither the compiler's own source (the self-host is byte-identical through the zig plug) nor the 28 programs we cut from `codex/test` contains a nested constructor pattern that changes an answer.

## The fix

**zig.** A match with a nested pattern, or with a Text literal pattern at any level, is compiled through the chain form the emitter already uses for guarded matches: each inner test is an `if` inside the enclosing one, and a failed inner test falls out of the arm to the next, which a switch prong cannot do (no fall-through, and two prongs on one constructor are a duplicate). `emit-zig-chain-work` walks the sub-patterns as a work list of (pattern, value) pairs — a constructor sub-pattern replaces itself with its own sub-patterns at the head of the list, each addressed through the payload, with `.*` when the field's type is boxed — and emits the arm's tail once, when the list is empty. A Text literal compares through `cx_text_eq`. Every variable bound anywhere in the pattern is pushed into the context the arm's body is emitted with. A match with no nested pattern and no Text literal takes exactly the paths it took; a match with a literal sub-pattern took the switch path before, wrongly.

**wasm.** `wat-ctor-sub-tests-at` and `emit-wat-bind-ctor-subs-at` take the object's address as an expression. A constructor sub-pattern is a tag test on the object its payload field points at; its own bindings and tests are emitted inside that tag test, so a payload load never addresses past an object of the wrong tag. The last-arm shortcut (`wat-ctor-has-test-subs`, renamed from `-lit-`) treats a constructor sub-pattern as the test it is. The scrutinee's forms call the new ones at `(local.get scrut)`, so a pattern with no nesting emits what it emitted.

## Pinned by a test unit

`codex/test/ops/match-nested-pattern`: twenty lines — payload bindings two and three levels deep, a multi-payload constructor inside another, an Integer and a Text literal inside a constructor, a Text literal on its own, nested nullary constructors, and formulas that differ only inside the nesting and must fall through. Both plugs fail it before (zig refuses, wasm answers wrong) and print its `.expected` after; the interpreter prints it either way. The programs quoted above are the Roc ports, not this unit; the unit's `describe` arm is `is Ok (Err (t)) -> 0 - text-length t`.

## Measurement

Stack: our `u58-candidate` = Update 57 `49fa9f27` + PRs 135, 138, 139, 140 + this commit; the PR branch is off clean `49fa9f27` and was not built at that base (the zig plug at `49fa9f27` predates PR 135's boxing and does not self-host the compiler). Bare metal is not measured here beyond the fixed points.

- **zig, self-host, no guest** (`bootstrap_native.py`): the second self-host build emits the first's bytes, in one round; the compiler's own source emits byte-identical zig through the old and new emitter, so it contains no nested pattern and no Text literal pattern.
- **zig, fixed point under QEMU** (`build.py --force`): **HOLDS, byte-identical** (`build.py --force`, 530 s, three guests; `arith` matches all 9 lines).
- **wasm, fixed point** (`build.py --road both`): **HOLDS** by both roads (`build.py --road zig` then `--road both`; the module compiles its own source and gets itself back, and the native road agrees with it; the sample matches).
- **Three corpora we run by output** (28 cut from `codex/test`, 46 Roc ports, 54 specs of safari, a 54-chapter application of ours), through each plug rebuilt from this stack, before → after: zig 28/28 → 28/28, 42/46 → 44/46 (the two left are COMPILER-74, an unconstrained type variable the checker never defaults), 51/54 → 51/54 (safari's three are Real literals one ULP apart, issue 125, the plugs' parser); wasm 28/28 → 28/28, 44/46 → 46/46, 51/54 → 51/54. The two that move are the two Roc programs above.
- **wasm, corpus sweep** (`corpus_sweep.py` over the 1,269 `codex/test` programs at Update 57, IR from a hosted `codexir`, graded against their own `.expected`), the plug at `49fa9f27` versus the plug with this commit: 830 match, 152 trap, 26 differ, 4 refused — **the same numbers and the same 26 programs** on both sides. The wasm change moves nothing in the corpus.

Risks: both emitters, on the match arm only. Every match without a nested pattern takes the code path it took, which is what the corpus numbers above are checking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012VqZFAQ561bYhSJ3gBoC3P
