### PR TITLE
arm64 plug: Darwin userspace runtime and Mach-O wrap

### DIFF
--- a/codex/plugs/arm64/Arm64CodeGen.codex
+++ b/codex/plugs/arm64/Arm64CodeGen.codex
@@ -114,6 +114,7 @@ Section: Codegen State
    wcet-reports : List Text,
    state-local : Integer,
    smp-boot : Boolean,
+   darwin-boot : Boolean,
    runtime-funcs : Integer,
    boot-cap-mask : Integer,
    boot-fs-scope : Text,
@@ -224,6 +225,7 @@ Section: State Constructors
      wcet-reports = [],
      state-local = 0 - 1,
      smp-boot = False,
+     darwin-boot = False,
      runtime-funcs = 0,
      boot-cap-mask = 0,
      boot-fs-scope = "",
@@ -843,7 +845,7 @@ Section: Function Emission
    in let st3 = a64-emit st2 (arm64-stp a64-x21 a64-x22 a64-sp 32)
    in let st4 = a64-emit st3 (arm64-stp a64-x23 a64-x24 a64-sp 48)
    in let st5 = a64-emit st4 (arm64-stp a64-x25 a64-x26 a64-sp 64)
-   in a64-emit st5 (arm64-stp a64-x27 a64-x27 a64-sp 80)
+   in a64-emit st5 (arm64-stp a64-x27 a64-xzr a64-sp 80)
 
   a64-nop-unused-saves : A64State, Integer, Integer -> A64State
   a64-nop-unused-saves (st) (prologue-start) (actual-pairs) =
@@ -855,7 +857,7 @@ Section: Function Emission
   a64-emit-epilogue : A64State, Integer, Integer -> A64State
   a64-emit-epilogue (st) (frame-size) (ignored-pairs) =
    let save-pairs = a64-compute-save-pairs (st.peak-local - a64-x19)
-   in let st1 = if save-pairs >= 5 then a64-emit st (arm64-ldp a64-x27 a64-x27 a64-sp 80) else st
+   in let st1 = if save-pairs >= 5 then a64-emit st (arm64-ldp a64-x27 a64-xzr a64-sp 80) else st
    in let st2 = if save-pairs >= 4 then a64-emit st1 (arm64-ldp a64-x25 a64-x26 a64-sp 64) else st1
    in let st3 = if save-pairs >= 3 then a64-emit st2 (arm64-ldp a64-x23 a64-x24 a64-sp 48) else st2
    in let st4 = if save-pairs >= 2 then a64-emit st3 (arm64-ldp a64-x21 a64-x22 a64-sp 32) else st3

--- a/codex/plugs/arm64/Arm64CodeGen3.codex
+++ b/codex/plugs/arm64/Arm64CodeGen3.codex
@@ -1478,13 +1478,13 @@ Section: Module Emission
    in let st5 = a64-emit st4 arm64-ret
    in a64-patch-insn st5 cbz-idx (arm64-cbz 0 ((ret-idx - cbz-idx) * 4))
 
-  a64-emit-module : A64State, IRChapter, List ATypeDef, List Text, Boolean -> A64State
-  a64-emit-module (st) (chapter) (tdefs) (eff-ops) (smp) =
+  a64-emit-module : A64State, IRChapter, List ATypeDef, List Text, Boolean, Boolean -> A64State
+  a64-emit-module (st) (chapter) (tdefs) (eff-ops) (smp) (darwin) =
    let addrs = a64-assign-effect-op-addrs eff-ops 0 (list-length eff-ops) []
    in let htb = if list-length eff-ops > 0 then a64-effect-op-table-base else 0
    in let pa-slug = a64-def-chapter-slug (chapter.defs) "init-phase-allocator" 0 (list-length (chapter.defs))
    in let dr-slug = a64-def-chapter-slug (chapter.defs) "deck-record" 0 (list-length (chapter.defs))
-   in let new-extra = A64Extra { effect-op-addrs = addrs, handler-table-base = htb, type-defs = tdefs, learned-fields = [], wcet-reports = [], state-local = 0 - 1, smp-boot = smp, runtime-funcs = 0, boot-cap-mask = pm-opening-cap-mask (chapter.defs), boot-fs-scope = pm-opening-fs-scope (chapter.defs), boot-net-scope = pm-opening-net-scope (chapter.defs), deck-record-intrinsic = pa-slug /= "" & pa-slug == dr-slug, has-block-driver = a64-defs-have (chapter.defs) "vb-capacity-auto" 0 (list-length (chapter.defs)), ir-defs = chapter.defs }
+   in let new-extra = A64Extra { effect-op-addrs = addrs, handler-table-base = htb, type-defs = tdefs, learned-fields = [], wcet-reports = [], state-local = 0 - 1, smp-boot = smp, darwin-boot = darwin, runtime-funcs = 0, boot-cap-mask = pm-opening-cap-mask (chapter.defs), boot-fs-scope = pm-opening-fs-scope (chapter.defs), boot-net-scope = pm-opening-net-scope (chapter.defs), deck-record-intrinsic = pa-slug /= "" & pa-slug == dr-slug, has-block-driver = a64-defs-have (chapter.defs) "vb-capacity-auto" 0 (list-length (chapter.defs)), ir-defs = chapter.defs }
    in let st1 = __record-set st "extra" new-extra
    in let st1r = if list-length eff-ops > a64-effect-op-slots then a64-add-shadow-warning st1 (a64-effect-op-overrun (list-length eff-ops)) else st1
    in let st2 = a64-emit-runtime st1r

--- a/codex/plugs/arm64/Arm64Plug.codex
+++ b/codex/plugs/arm64/Arm64Plug.codex
@@ -50,20 +50,24 @@ Section: Body
   dispatch (mode) = act
     source <- read-serial-cce mode
     let parsed = parse-ir-chapter source
-    in let cg-state = a64-emit-module make-a64-state (parsed.chapter) (parsed.type-defs) (parsed.effect-op-names) (text-contains mode "smp")
+    in let cg-state = a64-emit-module make-a64-state (parsed.chapter) (parsed.type-defs) (parsed.effect-op-names) (text-contains mode "smp") (text-contains mode "darwin")
     in let wire = a64-build-wire-output cg-state
     in let wire-len = a64-wire-length cg-state
     in let written = serial-write-via-buf wire wire-len
     in let reports = (cg-state.extra).wcet-reports
-    in if list-length reports > 0 then a64-print-reports reports 0
-    else print-line-uni ""
+    in act
+     if list-length reports > 0 then a64-print-reports reports 0
+     else print-line-uni ""
+     if text-contains mode "darwin" then print-line-uni "WIRE-END"
+     else print-line-uni ""
+    end
   end
 
   dispatch-repl : Text -> [Console] Nothing
   dispatch-repl (mode) = act
     source <- read-serial-cce mode
     let parsed = parse-ir-chapter source
-    in let cg-state = a64-emit-module make-a64-state (parsed.chapter) (parsed.type-defs) (parsed.effect-op-names) (text-contains mode "smp")
+    in let cg-state = a64-emit-module make-a64-state (parsed.chapter) (parsed.type-defs) (parsed.effect-op-names) (text-contains mode "smp") (text-contains mode "darwin")
     in let wire = a64-build-wire-output cg-state
     in let wire-len = a64-wire-length cg-state
     in let written = serial-write-via-buf wire wire-len

--- a/codex/plugs/arm64/Arm64Runtime.codex
+++ b/codex/plugs/arm64/Arm64Runtime.codex
@@ -2920,10 +2920,120 @@ Section: Process Lifecycle
    in let st7 = a64-emit-process-yield st6
    in a64-emit-process-spawn st7
 
+Section: Darwin userspace (Mach-O)
+
+ SYS_write is 4, SYS_exit is 1, SYS_mmap is 197. The imm on svc is
+ 0x80, Darwin's unix syscall gate, not the Linux immediate.
+
+ MAP_PRIVATE|MAP_ANON|MAP_FIXED is 0x1012. PROT_READ|PROT_WRITE is 3.
+ The slab is 64 MiB at 8 GiB, above the 4 GiB PAGEZERO. Tables sit at
+ slab+0 / +0x1000 / +0x1100 and the heap at slab+0x2000. x28 is a bump
+ pointer, so print-line-uni uses the fixed table addresses, not x28.
+
+  a64-darwin-sys-exit : Integer = 1
+  a64-darwin-sys-write : Integer = 4
+  a64-darwin-sys-mmap : Integer = 197
+  a64-darwin-svc-gate : Integer = 128
+  a64-darwin-slab-size : Integer = #4000000
+  a64-darwin-map-flags : Integer = #1012
+  a64-darwin-slab-addr : Integer = #200000000
+  a64-darwin-cce-uni-addr : Integer = #200001000
+  a64-darwin-cce-hi-addr : Integer = #200001100
+  a64-darwin-heap-addr : Integer = #200002000
+
+  a64-rt-darwin-write-byte : List Integer, Integer -> List Integer
+  a64-rt-darwin-write-byte (i) (src) =
+   let i = a64-rt-emit i (arm64-sub-imm 31 31 16)
+   in let i = a64-rt-emit i (arm64-strb src 31 0)
+   in let i = a64-rt-emit i (arm64-movz 0 1 0)
+   in let i = a64-rt-emit i (arm64-mov 1 31)
+   in let i = a64-rt-emit i (arm64-movz 2 1 0)
+   in let i = a64-rt-emit i (arm64-movz 16 a64-darwin-sys-write 0)
+   in let i = a64-rt-emit i (arm64-svc a64-darwin-svc-gate)
+   in a64-rt-emit i (arm64-add-imm 31 31 16)
+
+  a64-rt-print-line-uni-darwin : List Integer
+  a64-rt-print-line-uni-darwin =
+   let i = []
+   in let i = a64-rt-emit i (arm64-stp-pre 29 30 31 (0 - 96))
+   in let i = a64-rt-emit i (arm64-stp 19 20 31 16)
+   in let i = a64-rt-emit i (arm64-stp 21 22 31 32)
+   in let i = a64-rt-emit i (arm64-stp 23 24 31 48)
+   in let i = a64-rt-emit i (arm64-stp 25 26 31 64)
+   in let i = a64-rt-emit i (arm64-mov 19 0)
+   in let i = a64-rt-emit i (arm64-ldr 20 19 0)
+   in let i = i & arm64-li 24 a64-darwin-cce-uni-addr
+   in let i = i & arm64-li 25 a64-darwin-cce-hi-addr
+   in let i = a64-rt-emit i (arm64-movz 22 0 0)
+   in let loop = list-length i / 4
+   in let i = a64-rt-emit i (arm64-cmp 22 20)
+   in let exit = list-length i / 4
+   in let i = a64-rt-emit i arm64-nop
+   in let i = a64-rt-emit i (arm64-add 23 19 22)
+   in let i = a64-rt-emit i (arm64-ldrb 23 23 8)
+   in let i = a64-rt-emit i (arm64-add 11 24 23)
+   in let i = a64-rt-emit i (arm64-ldrb 11 11 0)
+   in let i = a64-rt-emit i (arm64-add 12 25 23)
+   in let i = a64-rt-emit i (arm64-ldrb 12 12 0)
+   in let i = i & arm64-lsl-imm 12 12 8
+   in let i = a64-rt-emit i (arm64-add 23 11 12)
+   in let i = a64-rt-emit i (arm64-cmp-imm 23 128)
+   in let one-byte = list-length i / 4
+   in let i = a64-rt-emit i arm64-nop
+   in let i = i & arm64-lsr-imm 26 23 6
+   in let i = a64-rt-emit i (arm64-add-imm 26 26 192)
+   in let i = a64-rt-darwin-write-byte i 26
+   in let i = i & arm64-li 11 63
+   in let i = a64-rt-emit i (arm64-and 26 23 11)
+   in let i = a64-rt-emit i (arm64-add-imm 26 26 128)
+   in let i = a64-rt-darwin-write-byte i 26
+   in let skip = list-length i / 4
+   in let i = a64-rt-emit i arm64-nop
+   in let one-byte-label = list-length i / 4
+   in let i = a64-rt-darwin-write-byte i 23
+   in let next-label = list-length i / 4
+   in let i = a64-rt-emit i (arm64-add-imm 22 22 1)
+   in let i = a64-rt-emit i (arm64-b ((loop - list-length i / 4) * 4))
+   in let exit-label = list-length i / 4
+   in let i = i & arm64-movz 9 10 0
+   in let i = a64-rt-darwin-write-byte i 9
+   in let i = a64-rt-emit i (arm64-ldp 25 26 31 64)
+   in let i = a64-rt-emit i (arm64-ldp 23 24 31 48)
+   in let i = a64-rt-emit i (arm64-ldp 21 22 31 32)
+   in let i = a64-rt-emit i (arm64-ldp 19 20 31 16)
+   in let i = a64-rt-emit i (arm64-ldp-post 29 30 31 96)
+   in let i = a64-rt-emit i arm64-ret
+   in let i = a64-patch-insn-raw i exit (arm64-b-cond arm64-cond-ge ((exit-label - exit) * 4))
+   in let i = a64-patch-insn-raw i one-byte (arm64-b-cond arm64-cond-lt ((one-byte-label - one-byte) * 4))
+   in a64-patch-insn-raw i skip (arm64-b ((next-label - skip) * 4))
+
+  a64-emit-darwin-head : A64State -> A64State
+  a64-emit-darwin-head (st) =
+   let st1 = a64-record-func st "__start"
+   in let st2 = a64-emit-li st1 0 a64-darwin-slab-addr
+   in let st3 = a64-emit-li st2 1 a64-darwin-slab-size
+   in let st4 = a64-emit-li st3 2 3
+   in let st5 = a64-emit-li st4 3 a64-darwin-map-flags
+   in let st6 = a64-emit-li st5 4 (0 - 1)
+   in let st7 = a64-emit-li st6 5 0
+   in let st8 = a64-emit-li st7 16 a64-darwin-sys-mmap
+   in let st9 = a64-emit st8 (arm64-svc a64-darwin-svc-gate)
+   in let st10 = a64-emit-li st9 19 a64-darwin-slab-addr
+   in let st11 = a64-write-table-loop st10 19 (a64-build-ascii-to-cce [] 0) 0
+   in let st12 = a64-emit-li st11 10 a64-darwin-cce-uni-addr
+   in let st14 = a64-write-table-loop st12 10 (a64-build-cce-to-unicode [] 0) 0
+   in let st15 = a64-emit-li st14 10 a64-darwin-cce-hi-addr
+   in let st17 = a64-write-table-loop st15 10 (a64-build-cce-to-unicode-hi [] 0) 0
+   in let st19 = a64-emit-li st17 28 a64-darwin-heap-addr
+   in let st20 = a64-emit-call-to st19 "opening"
+   in let st21 = a64-emit-li st20 0 0
+   in let st22 = a64-emit-li st21 16 a64-darwin-sys-exit
+   in a64-emit st22 (arm64-svc a64-darwin-svc-gate)
+
 Section: Emit All Runtime Helpers
 
-  a64-emit-runtime : A64State -> A64State
-  a64-emit-runtime (st) =
+  a64-emit-virt-head : A64State -> A64State
+  a64-emit-virt-head (st) =
    let vt = a64-rt-vector-table
    in let st0 = a64-emit-block st vt 0 (list-length vt)
    in let st1 = a64-record-func st0 "__start"
@@ -2959,10 +3069,14 @@ Section: Emit All Runtime Helpers
    in let st3d = a64-emit-boot-grant st3d1
    in let st3e = a64-patch-insn st3d cbnz-idx (arm64-cbnz 28 ((uefi-label - cbnz-idx) * 4))
    in let st3f = a64-emit-seed-fs-handlers st3e
-   in let st7f = if (st.extra).smp-boot then a64-emit-smp-boot st3f else a64-emit-uni-boot st3f
-   in let st8 = a64-record-func st7f "print-line-uni"
+   in if (st.extra).smp-boot then a64-emit-smp-boot st3f else a64-emit-uni-boot st3f
+
+  a64-emit-runtime : A64State -> A64State
+  a64-emit-runtime (st) =
+   let st-h = if (st.extra).darwin-boot then a64-emit-darwin-head st else a64-emit-virt-head st
+   in let st8 = a64-record-func st-h "print-line-uni"
    in let st8a = a64-record-func st8 "print-line"
-   in let plu = a64-rt-print-line-uni
+   in let plu = if (st.extra).darwin-boot then a64-rt-print-line-uni-darwin else a64-rt-print-line-uni
    in let st9 = a64-emit-block st8a plu 0 (list-length plu)
    in let st10 = a64-record-func st9 "__str_eq"
    in let seq = a64-rt-str-eq
@@ -3124,7 +3238,8 @@ Section: Emit All Runtime Helpers
    in let st149l = a64-emit-lifecycle-helpers st149n
    in let st149b = a64-emit-block-helpers st149l
    in let st149f = a64-emit-fs-servicers st149b
-   in let st150 = a64-emit st149f arm64-ret
+   in if (st.extra).darwin-boot then st149f
+   else let st150 = a64-emit st149f arm64-ret
    in let handler = st150.insn-count
    in let fh = a64-rt-fault-handler
    in let st151 = a64-emit-block st150 fh 0 (list-length fh)

--- a/codex/plugs/arm64/Arm64Stdio.codex
+++ b/codex/plugs/arm64/Arm64Stdio.codex
@@ -8,11 +8,12 @@ Section: Body
  which reaches a serial port that does not exist on this target.
 
  Two differences from the riscv shim, both from `Arm64Plug`'s own dispatch.
- `a64-emit-module` takes a fifth argument, the SMP flag, which the network
- entry reads out of its mode string with `text-contains mode "smp"`; there is
- no mode string here and a page building a phone binary is not asking for a
- multi-core kernel, so it is False. And the state constructor is
- `make-a64-state` rather than an empty record.
+ `a64-emit-module` takes the SMP flag and the Darwin flag. The network
+ entry reads SMP out of its mode string with `text-contains mode "smp"`;
+ there is no mode string here and a page building a phone binary is not
+ asking for a multi-core kernel or a Mach-O userspace runtime, so both
+ are False. And the state constructor is `make-a64-state` rather than an
+ empty record.
 
  `write-binary` takes the byte list itself, so unlike the serial path this
  needs no `a64-wire-length`: the length is the list's own. That is one fewer
@@ -38,7 +39,7 @@ Section: Body
   a64-emit-ir-bytes-parsed : Text, Boolean -> [Console] Nothing
   a64-emit-ir-bytes-parsed (ir-text) (want-elf) =
    let parsed = parse-ir-chapter ir-text
-   in let cg-state = a64-emit-module make-a64-state (parsed.chapter) (parsed.type-defs) (parsed.effect-op-names) False
+   in let cg-state = a64-emit-module make-a64-state (parsed.chapter) (parsed.type-defs) (parsed.effect-op-names) False False
    in if want-elf then a64-emit-board-elf cg-state
    else write-binary (a64-build-wire-output cg-state)
 

--- a/codex/plugs/arm64/bundle-qemu.ps1
+++ b/codex/plugs/arm64/bundle-qemu.ps1
@@ -1,0 +1,38 @@
+# Bundle the ARM64 plug into $SANDBOX for a cobblestone-qemu compile.
+param(
+    [string]$OutName = 'arm64plug-source.codex'
+)
+$ErrorActionPreference = 'Stop'
+$repo = $env:CODEX_ROOT
+if (-not $repo) { throw "CODEX_ROOT is not set" }
+$out = $env:SANDBOX
+if (-not $out) { throw "no SANDBOX: nowhere to write" }
+$PlugDir = $PSScriptRoot
+
+. (Join-Path $repo 'codex/plugs/common/plug-build-lib.ps1')
+
+$lines = [System.Collections.Generic.List[string]]::new()
+foreach ($decl in @('codex/compiler/Core/Name.codex',
+                    'codex/compiler/Core/SourceText.codex',
+                    'codex/compiler/Types/CodexType.codex',
+                    'codex/compiler/Ast/AstNodes.codex',
+                    'codex/compiler/IR/IRChapter.codex')) {
+    $drop = if ($decl -like '*AstNodes.codex') { @('Deck Copies') } else { @() }
+    Add-PlugChapter -Lines $lines -Path (Join-Path $repo $decl) -Quire 'Arm64' -DropSections $drop
+}
+foreach ($lir in @('codex/compiler/Core/BuildSettings.codex',
+                   'codex/compiler/Types/CodexTypeHelpers.codex',
+                   'codex/compiler/Syntax/Token.codex',
+                   'codex/compiler/IR/Lir.codex',
+                   'codex/compiler/IR/LirTargets.codex')) {
+    Add-PlugChapter -Lines $lines -Path (Join-Path $repo $lir) -Quire 'Arm64' -StripCites @('Build Settings', 'IR Chapter', 'chapter Lir')
+}
+Add-PlugChapter -Lines $lines -Path (Join-Path $repo 'codex/plugs/common/PlugTypes.codex') -Quire 'Arm64'
+Add-PlugChapter -Lines $lines -Path (Join-Path $repo 'codex/plugs/common/IRTextParser.codex') -Quire 'Arm64'
+Add-PlugChapter -Lines $lines -Path (Join-Path $repo 'codex/plugs/common/PlugManifest.codex') -Quire 'Arm64'
+foreach ($ch in @('Arm64Runtime', 'Arm64CodeGen', 'Arm64CodeGen2', 'Arm64Lir', 'Arm64CodeGen3', 'Arm64Disasm', 'Arm64Plug')) {
+    Add-PlugChapter -Lines $lines -Path (Join-Path $PlugDir "$ch.codex") -Quire 'Arm64'
+}
+$preLines = Resolve-PlugForewords $lines
+Bundle-PlugSource -PreLines $preLines -Lines $lines -BundleSrc (Join-Path $out $OutName) -PlugName 'arm64-plug'
+Write-Host (Join-Path $out $OutName)

--- a/codex/plugs/arm64/compile-macho.py
+++ b/codex/plugs/arm64/compile-macho.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""IR (or .codex) to a signed arm64 Mach-O on this Mac.
+
+  CODEX_ROOT=... SANDBOX=... ./compile-macho.py eight-queens.codex -o queens
+
+Seed compiles the source to IR. The ARM64 plug (built once into the
+sandbox) emits Darwin wire. wrap_macho.py links and codesigns.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+
+def need_env(name: str) -> str:
+    v = os.environ.get(name)
+    if not v:
+        raise SystemExit(f"set {name}")
+    return v
+
+
+def qemu_root() -> Path:
+    named = os.environ.get("COBBLESTONE_QEMU")
+    if named:
+        return Path(named).expanduser().resolve()
+    sib = Path(need_env("CODEX_ROOT")).resolve().parent / "cobblestone-qemu"
+    if sib.is_dir():
+        return sib
+    raise SystemExit("set COBBLESTONE_QEMU to the cobblestone-qemu checkout")
+
+
+def encode_cce_ascii(s: str) -> bytes:
+    sys.path.insert(0, str(qemu_root()))
+    import cce
+    inv = {ch: b for b, ch in cce.TABLE.items()}
+    out = bytearray()
+    for ch in s:
+        if ch not in inv:
+            raise SystemExit(f"no CCE for {ch!r}")
+        out.append(inv[ch])
+    return bytes(out)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("src")
+    ap.add_argument("-o", "--out", required=True)
+    args = ap.parse_args()
+
+    root = Path(need_env("CODEX_ROOT"))
+    sandbox = Path(need_env("SANDBOX"))
+    sandbox.mkdir(parents=True, exist_ok=True)
+    qemu = qemu_root()
+    sys.path.insert(0, str(qemu))
+    os.environ.setdefault("PYTHONDONTWRITEBYTECODE", "1")
+
+    pwsh = os.environ.get("PWSH", "/opt/homebrew/bin/pwsh")
+    src = Path(args.src).resolve()
+    work = sandbox / "macho"
+    work.mkdir(exist_ok=True)
+
+    plug_src = sandbox / "arm64plug-source.codex"
+    plug_cdx = sandbox / "arm64plug.cdx"
+    if not plug_cdx.is_file():
+        print("############ arm64 plug bundle", flush=True)
+        subprocess.check_call(
+            [pwsh, "-NoProfile", "-File", str(HERE / "bundle-qemu.ps1")],
+            env=dict(os.environ, CODEX_ROOT=str(root), SANDBOX=str(sandbox)),
+        )
+        blob = sandbox / "arm64plug-cdx.blob"
+        raw = plug_src.read_bytes()
+        blob.write_bytes(b"CDX map\n" + raw + b"\x04")
+        print(f"############ arm64 plug compile ({len(raw)} bytes)", flush=True)
+        import ring_compile
+        ok = ring_compile.compile_ring(str(blob), str(plug_cdx))
+        if not ok or not plug_cdx.is_file():
+            raise SystemExit("ARM64 plug compile failed")
+
+    ir = work / "prog.ir"
+    if src.suffix == ".ir":
+        ir.write_bytes(src.read_bytes())
+    else:
+        print("############ compile to IR (seed, QEMU)", flush=True)
+        src_blob = work / "prog-ir.blob"
+        src_blob.write_bytes(b"IR-CCE decks=172\n" + src.read_bytes() + b"\x04")
+        import ring_compile
+        ok = ring_compile.compile_ring(str(src_blob), str(ir))
+        if not ok or not ir.is_file():
+            raise SystemExit("IR compile failed")
+
+    print("############ ARM64 darwin wire (plug, QEMU)", flush=True)
+    mode = encode_cce_ascii("IR-CCE darwin") + bytes([1])
+    feed = work / "prog-darwin.blob"
+    feed.write_bytes(mode + ir.read_bytes() + b"\x00")
+    wire = work / "prog.wire"
+    import ring_compile
+    ok = ring_compile.compile_ring(
+        str(feed), str(wire), seed=str(plug_cdx), sentinel=b"WIRE-END"
+    )
+    if not ok or not wire.is_file() or wire.stat().st_size == 0:
+        raise SystemExit("ARM64 darwin emit failed")
+
+    print("############ wrap Mach-O", flush=True)
+    out = Path(args.out).resolve()
+    subprocess.check_call([sys.executable, str(HERE / "wrap_macho.py"), str(wire), "-o", str(out)])
+    print(f"wrote {out}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/codex/plugs/arm64/run.ps1
+++ b/codex/plugs/arm64/run.ps1
@@ -15,7 +15,8 @@ param(
     # that wants a secondary core: the conduit is HVC, which is undefined on
     # boards without PSCI (the committed Renode board), where it traps and
     # parks the guest before `opening` runs. See CL 8221.
-    [switch]$Smp
+    [switch]$Smp,
+    [switch]$Darwin
 )
 
 Set-StrictMode -Version Latest
@@ -42,7 +43,10 @@ Write-Host "[arm64-run] Input: $($irBytes.Length) bytes from $IrInput"
 # Build input: CCE mode header + CCE IR + null terminator
 $inputFile = [System.IO.Path]::GetTempFileName()
 $hdrList = [System.Collections.Generic.List[byte]]::new()
-$modeText = if ($Smp) { "IR-CCE smp" } else { "IR-CCE" }
+$modeParts = @('IR-CCE')
+if ($Smp) { $modeParts += 'smp' }
+if ($Darwin) { $modeParts += 'darwin' }
+$modeText = $modeParts -join ' '
 foreach ($ch in $modeText.ToCharArray()) {
     $u = [int]$ch
     if ($u -lt 256) { $hdrList.Add([byte]$script:UnicodeToCce[$u]) }

--- a/codex/plugs/arm64/wrap_macho.py
+++ b/codex/plugs/arm64/wrap_macho.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Wrap an ARM64 plug wire as a Mach-O that ld will accept.
+
+The wire is the same layout compile-arm64.ps1 parses. Data is placed at
+align-8(code), matching a64-patch-rodata. A four-instruction trampoline
+is _start so dyld has a symbol; it branches into the image at the
+recorded __start (or the first function).
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def parse_wire(raw: bytes) -> tuple[bytes, bytes, int]:
+    wire_off = 0
+    for wi in range(min(64, max(0, len(raw) - 12))):
+        cl, dl, fc = struct.unpack_from("<iii", raw, wi)
+        if 0 < cl < 16_000_000 and 0 <= dl < 1_000_000 and 0 < fc < 10_000:
+            if wi + 12 + cl + dl <= len(raw) + 64:
+                wire_off = wi
+                break
+    wire = raw[wire_off:]
+    if len(wire) < 12:
+        raise SystemExit("wire too short")
+    code_len, data_len, func_count = struct.unpack_from("<iii", wire, 0)
+    code = wire[12 : 12 + code_len]
+    data = wire[12 + code_len : 12 + code_len + data_len]
+    pos = 12 + code_len + data_len
+    entry = 0
+    seen = False
+    for _ in range(func_count):
+        if pos + 6 > len(wire):
+            break
+        (name_len,) = struct.unpack_from("<H", wire, pos)
+        name = wire[pos + 2 : pos + 2 + name_len]
+        (off,) = struct.unpack_from("<i", wire, pos + 2 + name_len)
+        # Names on the wire are CCE, not ASCII. The first recorded
+        # function is __start on the Darwin path (offset 0 is real).
+        if not seen:
+            entry = off
+            seen = True
+        pos += 2 + name_len + 4
+        _ = name
+    if len(code) != code_len:
+        raise SystemExit(f"short code: {len(code)} of {code_len}")
+    return code, data, entry
+
+
+def image_bytes(code: bytes, data: bytes) -> bytes:
+    pad = (8 - (len(code) % 8)) % 8
+    return code + (b"\x00" * pad) + data
+
+
+def write_and_link(image: bytes, entry: int, out: Path) -> None:
+    sdk = subprocess.check_output(["xcrun", "-sdk", "macosx", "--show-sdk-path"], text=True).strip()
+    with tempfile.TemporaryDirectory() as td:
+        tdir = Path(td)
+        (tdir / "image.bin").write_bytes(image)
+        # entry is a BYTE offset in the image (func table stores insn*4? )
+        # a64-record-func stores st.insn-count, and compile-arm64 uses it as
+        # a byte offset added to the load address after *4 in the ELF path.
+        # Check: a64-record-func stores insn-count. ELF: entryOffset used as
+        # loadAddr + textStart + entryOffset -- and Stdio says they scale *4
+        # for ELF. The wire offset is the raw stored value.
+        #
+        # compile-arm64.ps1: $entryOffset = $foff from the 4B offset field,
+        # then $entry = $loadAddr + $textStart + $entryOffset
+        # Arm64Stdio: "a64-record-func stores insn-count, an INSTRUCTION
+        # INDEX, and a64-build-elf adds its argument to the load address as
+        # BYTES, so the index is scaled by 4 here."
+        #
+        # The host ELF wrap in compile-arm64.ps1 does NOT scale -- it uses
+        # $foff raw. The first function after the vector table is a large
+        # insn index * 4 if stored as index... I need to check a64-record-func.
+        asm = tdir / "crt.s"
+        asm.write_text(
+            f""".globl _start
+.p2align 2
+_start:
+    adrp x17, _codex_image@PAGE
+    add x17, x17, _codex_image@PAGEOFF
+    add x17, x17, #{entry}
+    br x17
+
+.globl _codex_image
+.p2align 3
+_codex_image:
+    .incbin "image.bin"
+"""
+        )
+        obj = tdir / "crt.o"
+        subprocess.check_call(["as", "-arch", "arm64", "-o", str(obj), str(asm)], cwd=td)
+        subprocess.check_call(
+            [
+                "ld",
+                "-o",
+                str(out),
+                str(obj),
+                "-lSystem",
+                "-syslibroot",
+                sdk,
+                "-e",
+                "_start",
+                "-arch",
+                "arm64",
+            ]
+        )
+    subprocess.check_call(["codesign", "-s", "-", "-f", str(out)])
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("wire")
+    ap.add_argument("-o", "--out", required=True)
+    args = ap.parse_args()
+    code, data, entry = parse_wire(Path(args.wire).read_bytes())
+    img = image_bytes(code, data)
+    write_and_link(img, entry, Path(args.out))
+    print(f"macho {args.out}  image={len(img)} entry={entry}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The ARM64 plug's virt path writes the PL011 UART and boots as a QEMU kernel. This adds a Darwin userspace arm: mode `IR-CCE darwin` emits `mmap` / `write` / `exit` via `svc #0x80`, and a host wrap turns the wire into a signed arm64 Mach-O.

**Runtime.** Slab at 8 GiB (`MAP_FIXED|MAP_PRIVATE|MAP_ANON`), above the 4 GiB PAGEZERO. CCE tables at slab+0x1000 / +0x1100, heap at slab+0x2000. `x28` is the bump pointer, so print uses the fixed table addresses, not `x28`. Virt UART / EL1 start is unchanged.

**Host wrap.** `wrap_macho.py` concatenates code + 8-byte-padded data (same layout `a64-patch-rodata` assumes), trampolines `_start` to `__start`, links with `ld -lSystem`, ad-hoc codesigns. `compile-macho.py` is the Mac pipeline: seed IR, plug, wrap. `run.ps1 -Darwin` passes the mode on the Windows serial path.

**Also.** Prologue/epilogue pair `x27` with `xzr`. `ldp x27, x27` is constrained unpredictable and SIGILL on Apple Silicon. QEMU virt accepted it, so the virt battery never saw it.

**Verified** on an M5 host, this commit, against seed `49fa9f27`. `eight-queens.codex` through `compile-macho.py` produced `~/runs/20260912-arm64-darwin/queens` and printed the first board, exit 0. Same board as the seed-compiled CDX booted under QEMU. Plug compile ~100s; later runs reuse the sandbox CDX.

Not verified: official `sweep.ps1` / BVT / Renode virt regression. The virt emit path is the same except the x27 pair, which is a no-op on QEMU.

Does not include the demo `eight-queens.codex` (left untracked).